### PR TITLE
[Sikkerhet] Oppretter sikkerhetsmappa med beskrivelse.yaml (v2.0) og legger til Security Champion i CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 /.security/ @ljooys
-* @kartverket/team-bygning
+* @kartverket/bygning
 /.sikkerhet/ @ljooys

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 /.security/ @ljooys
 * @kartverket/team-bygning
+/.sikkerhet/ @ljooys

--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,0 +1,5 @@
+version: 2.0
+organization: Eiendom
+product: Bygning Egenregistrering
+repo_types: [Tool]
+platforms: []


### PR DESCRIPTION
## Kort forklart
Denne PRen oppretter filen `.sikkerhet/beskrivelse.yaml`, og `.github\CODEOWNERS` dersom `CODEOWNERS` ikke allerede finnes

I `CODEOWNERS` legges det til linjen `/.sikkerhet/ @ljooys`, der `ljooys` er GitHub-brukernavnet til den som skal være teamets kontaktperson om sikkerhet ([Security Champion](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732332108/Security+Champion)).

I `/.sikkerhet/beskrivelse.yaml` legges følgende felter legges inn:

- `version: 2.0`
- `organization: Eiendom`
- `product: Bygning Egenregistrering`
- `repo_types: [Tool]`
- `platforms: []`

## Litt lenger forklart (hvorfor gjør vi dette?)
Det er beskrevet [her i Sikkehertshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet).