### PR TITLE
[Sikkerhet] Oppdaterer med catalog-info.yaml til versjon 3.0

### DIFF
--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 3.0
 organization: Eiendom
 product: Bygning Egenregistrering
 repo_types: [Tool]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,38 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "bygning-github-workflows"
+  tags:
+  - "private"
+spec:
+  type: "service"
+  lifecycle: "production"
+  owner: "bygning"
+  system: "matrikkel"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Group"
+metadata:
+  name: "security_champion_bygning-github-workflows"
+  title: "Security Champion bygning-github-workflows"
+spec:
+  type: "security_champion"
+  parent: "eiendom_security_champions"
+  members:
+  - "ljooys"
+  children:
+  - "resource:bygning-github-workflows"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Resource"
+metadata:
+  name: "bygning-github-workflows"
+  links:
+  - url: "https://github.com/kartverket/bygning-github-workflows"
+    title: "bygning-github-workflows på GitHub"
+spec:
+  type: "repo"
+  owner: "security_champion_bygning-github-workflows"
+  dependencyOf:
+  - "component:bygning-github-workflows"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage, samtidig som `beskrivelse.yaml` nå går til `version: 3.0`.
Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.