### PR TITLE
[Sikkerhet] Oppretter initiell risiko- og sårbarhetsanalyse (RoS)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 /.security/ @ljooys
 * @kartverket/bygning
-/.sikkerhet/ @ljooys
+/.security/ @ljooys

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,5 +1,4 @@
-version: 3.0
 organization: Eiendom
-product: Matrikkel
-repo_types: [Ops]
-platforms: [SKIP]
+product: Bygning Egenregistrering
+repo_types: [Tool]
+platforms: []

--- a/.security/risc/.sops.yaml
+++ b/.security/risc/.sops.yaml
@@ -1,0 +1,12 @@
+creation_rules:
+- path_regex: \.risc\.yaml$
+  shamir_threshold: 2
+  key_groups:
+  - age:
+    - age145s860ux96jvx6d7nwvzar588qjmgv5p47sp6nmmt2jnmhqh4scqcuk0mg
+    gcp_kms:
+    - resource_id: 
+        projects/matrikkelbygning-prod-9e62/locations/europe-north1/keyRings/matrikkelbygning-risc-key-ring/cryptoKeys/matrikkelbygning-risc-crypto-key
+  - age:
+    - age18e0t6ve0vdxqzzjt7rxf0r6vzc37fhs5cad2qz40r02c3spzgvvq8uxz23
+    - age1kjpgclkjev08aa8l2uy277gn0cngrkrkazt240405ezqywkm5axqt3d3tq

--- a/.security/risc/risc-default.risc.yaml
+++ b/.security/risc/risc-default.risc.yaml
@@ -1,0 +1,799 @@
+schemaVersion: ENC[AES256_GCM,data:LvkC,iv:BTKVhRZR6ebpM+ErQMq0p+RZTJI7US+Yg7Ulf3TROb8=,tag:s70o4yZ+Jp9gt54YL8m1lg==,type:str]
+title: ENC[AES256_GCM,data:57AkSE/ZVe+Pm/5pEoK1UjRoGgH8tg==,iv:DxoaO+tXyLiwH5/Cf2OsDiAj7Y/lRInbEUvKdG53GDk=,tag:ulcqhMouixwkfRXInVhq+A==,type:str]
+scope: ENC[AES256_GCM,data:LoLonSm5X3mq7OIAQszOmiuOC1PJy8eMJ7e1jF8CzGVdLN2E18xZUj6oegwfDKog/n1kvXZy8huxckw/gIm1xH+SXrdZNKBrhtmhosIvSrGjPaQ2kvM4DgatF1InxGhENsRos+dU/s7PkoDCrAr0BxGgdDkMm5x7iO5NZFBTNWyFMTR+jNl6sgqFZZY9gpHuitwChEReydvgFGiIkx6IaWuUNDvGzlUc4I7GsWkdY64BE5IA7QM72Ti5s0rDj6BTVLqsRGtjMnEcfcLVikFW5w==,iv:l3QHykuMd8zU8aZ++Mi4Wnek6Np9mdvWFiBFiH8Znug=,tag:3bX+qjvwPdnB9ePrSXkQVA==,type:str]
+valuations:
+    - description: ENC[AES256_GCM,data:4nFRB04OThqbGCpOUEX5gCl08ANXda34qalFDe0y4G3PKUvRhgc46N8lICerzv1Waz7r,iv:U1TA/sLWHFOCJkrV+aw/jTg6aqZOTie3pAhbgnSp6r8=,tag:h6UnFuwyLV9gzGGq8DXnKg==,type:str]
+      confidentiality: ENC[AES256_GCM,data:aqrnJobEkMj6lAb+,iv:UspImIOSVXUy6wMTI8Wj4C+rZCVOZLEspXENVJ269Eo=,tag:fjmaOAPgu1tTsCCte5WEjw==,type:str]
+      integrity: ENC[AES256_GCM,data:DwpLtnJEft4=,iv:Ra2R0HD5ahjIe2u3X8EM60/irVAtvTnbi1uK47+3iuI=,tag:fhp22/t8+X1sW7CbrVnBbQ==,type:str]
+      availability: ENC[AES256_GCM,data:dlIFiTg4FQ==,iv:+Tz5IzT8nQ8+fMCCM4c12EOR+JbbZz4p3z9Bw/8pK00=,tag:BrHw9jpFMaokAjxWo6jl9A==,type:str]
+    - description: ENC[AES256_GCM,data:CFo4V+tLHYTWgS23fdXc6fCe5yrQz82+0HXbIbb/mEmTnxbR40kXY7rxOJwCKrvCAr2RdtXV75jbMICrNBS3buE=,iv:v1J2oh5eB55wRFcVgWBF+a9sSykCrwXX+qndKepPy9o=,tag:/0LFzMw2tj15P6IbLs7mFw==,type:str]
+      confidentiality: ENC[AES256_GCM,data:9lJzOLoSWM+1rlBBa5kuILRpU9cw,iv:NjetF1ifXIOHb3CqylXdOMN5NGeOuKk2p0Ta9rehM4U=,tag:0FYHXQI0n9SUbYI20hCIfA==,type:str]
+      integrity: ENC[AES256_GCM,data:tLPn0ZYiUo0=,iv:JiSzg8vAC1uJoaZnWQc3ZGbvEsOW/qj2rF754L+PT3s=,tag:DyuAAWhoG60fzp/3ZQZ64w==,type:str]
+      availability: ENC[AES256_GCM,data:F3lg+LuLlw==,iv:tta9GjvlRGloWY7iaXUof84zoKa8W2ERZR2sWKn0Xng=,tag:bPJwheiB+TbhjfiMDT8L4w==,type:str]
+    - description: ENC[AES256_GCM,data:+KoHhrXdtvxm2S6H02Cu0uSeo3ae4zLVqYabdF2inzdNWU6ogdIG+CmXGDWQWihSa2812vxY7DrOLFiPSjRqBxkshfGHbPvyVrPV4wqmmDtGlv96VnwZcg+J,iv:u8edcLX9umPWinsX5iGql947sPv61hBrrQcANayqaDA=,tag:jPtrLQTS8cAfH4GOAAwxlA==,type:str]
+      confidentiality: ENC[AES256_GCM,data:gYZp8x9ZSoc=,iv:kFa2C45omxIC17M6ppGkIcEp13dqxOXuVSRg2c/UOec=,tag:NO9p26KDspztQ/JtdNTYmA==,type:str]
+      integrity: ENC[AES256_GCM,data:/ahQuANGQm4=,iv:hMR4Bfk8Sj2S+GuaM+Ldqt9I/DVmlzblvnoWf10EbZE=,tag:pRfkUDXxFnYjEhX5wA1Dwg==,type:str]
+      availability: ENC[AES256_GCM,data:uC1iOxXT,iv:/ZzhW2acAf1oHQkgvU8t0B7Xv9auje+sJrd+fa0UCGU=,tag:o55cCsYteuMJZdnIQOajPg==,type:str]
+scenarios:
+    - scenario:
+        ID: ENC[AES256_GCM,data:A4Mxtb0=,iv:Ylv2kSGOJbwj+a522Tv9awm3/mnLimrb2hV4WOGnV04=,tag:Y3+wfrLc8YIXLOGSYu35Vw==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:zQXma9o=,iv:POzTVFN3elW001uCuO0VTXx1l/E0H3zHOkNRmPEQBkY=,tag:6K57imlCE55rCwyQJLo54g==,type:str]
+                description: ENC[AES256_GCM,data:Gj7dWyswUXQNOaBUrKOm5UX7B5lEp+zVNJeIoCsT2EwJYb4CLqgHbjOyPbry7/lCnFZmiDCQWhTKVRgdUNDTCNxZuLHCfCDyARZzWfVnVmAAo6AuRi5l5JB8nIw7EQtJqupVC5vWUzm1IA0ETOkL43wMp8kKDeAJS5J4Ruj4TCsxT3oKZRYrLMcdygrsTIh5lFGHkolDRRNwEA54rc/RE579BXNagY55jfNGYCSBMjs2uETEFtUXKNUuOJahmBRMGY1lTwkaq4CLdDE06P9tJlWTMUSJIVXqAIofv/vBTx4mKG+5rySjePfmtkvpwG7hw1uwt05IKtNMaEtm6CjYOHS90AKLXCZrmpUpUQwPojFf3QFaCo4J1z65b8+SUKwgzcWnP7n8,iv:shZ2Mky1fP8Ag4U9LtgD5NzdVAt4Dss8vzNJptqofJQ=,tag:nz+sDsp2btRYp7kZyXa44g==,type:str]
+                status: ENC[AES256_GCM,data:pSCCt6+Cy24SIY0=,iv:mEpVFWuV+OyajZqOGADe4CrSfKX87gn5UyWib49K32U=,tag:iOMTjEMFYrm8BWpNsK0lNg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:/svGVmEZ6LQFFJn7nrxOod6GBb4pbo8=,iv:gTo2zgxgV9TzzhMf8Y6hqcihRcq7TL5H8b1kAsqAOVI=,tag:KoodqfruQDP9bqL2nxbAYw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:g/yJMBU=,iv:gJITaPOWsiYR8eoqd6mAMCYLdyXkkbuEZ8GJZnT8rOw=,tag:i/QtLmJhajj16wNimyxLpg==,type:str]
+                description: ENC[AES256_GCM,data:YtlgWitks7hwBXdwXpz+rUr6Z5dRid6s/5LzMwt0sXF323bR++6qpWkcwUM+Pi80QfB/g5wLEiMNP/JYk1MuAHiqrAa/dnc3svfgjXvpB1VEBHh7qH8XJkQSjbNtcCzGjyKqnKPXDl3IqTgSOET7f224pdLdzikUUomHxx8HO6PRqolbA2LyBT9Dzp87KG/UwiVKJewti0LCd598OCJ/fZRvx/1Tu4uBccYpcHJsvjIlZi++GU1gmkVdFfqUW7r8cdGG+X8dwJhHOoyZAel8iK4dFlGrRy0r8Dsy28b3vPo2lVwPZFW4qw4dBNFZoWntnY0DYuCX/5QBLJmiIN3l/43U1kgyD2QfvLC87hip8QxB0dyWA4NPy47XvZryr7VyJj+nB8/zocKVV6QlN0q1yLes19PL4CGhVMBf147vwXyai6RGlQK8clFKxeqTwQRUM/SWnCok9VwX4CyO1gaA5PdtSw==,iv:AR6Dryv/qdMX+q6nNRlKXwgeMdy2KzSBDmeSPWEYZdw=,tag:pl24Y1CYte3vMAJMGs28uw==,type:str]
+                status: ENC[AES256_GCM,data:4GNZzTdvJNPXq08=,iv:v1sLmM+Lm9WDTX0uHJyT8esJn4tBmlsBJXHG9EvJONU=,tag:rjkfN68uy6tq7FFD5WEHRA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:/PH94gkBZbBEAwVyEz5VaKBKYoAvNHq0sWw=,iv:fi1n6BsDJtqc31VWWENN4K69RpYe/6L8JO7jIQQuqag=,tag:ZYMcBjbtQXv0dMkd0MiRYA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:YVC0iwI=,iv:G1A99U2fyfWN3/yhstbqPD8ZLtZuFkyYlzj1OhQLmP0=,tag:bGzn7GvLVSJPACBIqYBkiw==,type:str]
+                description: ENC[AES256_GCM,data:0q8/Jja26bx8hZeLpdtlo62fZmDhShpamJob4c+S85FPSG4Nakv9ZMa9Uq815n2VZj1rO+zug60yuDmUYzXZY5tlbPyErn6b+IE+MqsMayyhj1t47a6xCLBIXpCgrkAl6Le9fiuI8ZiTII6zHs0ywMMx7RllXrFE70cgpvce/XKtLOPh+1vi6D/GAf62upLckcjZcHPZqVz3XUNDv33gw0WgbqXZSJBVVT9OGd7y31SJVXneEr9N05A1FN6pECebDSZP6HBYnhnfgdaXUTwCS2xK7A==,iv:qx4zq2xAOdXg2acizxitiDCKNFjlwNZpZ44EDw9LnDo=,tag:vOt3JLSgsLPMZn2BHgL82g==,type:str]
+                status: ENC[AES256_GCM,data:aS7fQKsyLlgwLKk=,iv:8uvVFfgc+vV2h+byEH3cT1+1fLM89Fh63GDz3tVKpNc=,tag:9eRW5bHORzME3cc+/ULQEw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:XSfK+1u5yHUgPsIOukUL6ijCz35lKg==,iv:6rr5X39BkgOQ3iwTfnC/93E2BwfRcJ4qqfm6TvYWAU4=,tag:K6t6UT57lr9UjBIokvkNqg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:UGrahiE=,iv:Q5UxtsHuCOBN+4bt8rurdp8qORAk2C5icbg2RJ6UrgY=,tag:EozUGjqU9CWJA1HuIKUmDA==,type:str]
+                description: ENC[AES256_GCM,data:cR4mzpcMMktM1LgpW5L9XFhH0PhplFn0BMQjHVh4nXkncU1Sl5sTUr9HCD17tPj5fTb3OTsKHr5rXtyxIWt8FK/f9B9gw7khaq3CTGFrJD2eobncPumnYPRhJmBA+k4pV0zYx705DGeJU/NqdaLUI8pi5v7mmI9gMEtRJtTziqA5zVnmYodZwd3NtxogPyGtgzLAgzivIThsXVtY06AsF1vNUao0lH7bTAwtln+qRsGZtr4tX8I9j1QR5VSwqxStXEjBTN9H/oGg7hY/aEyF6dP8bHsnlxvxA5KAC1DJltds+uWoE3R7O7EIWYpRyfNSEbeO4gBvgi/0aT3B5qR6jhDr5qzh/ScID9Gwau6O7IshzCyFrM7szIXFv/gwtjVtUZG/Tj63hiuBvZVi+QK/CJfNnVE7GkBVy8EjAMrLcJlwy3xQ8ES93Jt2BDt0G8RREqkDLRtcxXiw/silhvUOAY+lmMaZUcEpn1SsPX7kI7p3WnLQJqvck0j8CiK5Zm2oYt/9Cd89VGNrwL4UjLry5PWnNr/wO4mt4iVgc7uFtG1i4YDN2x1wEud1HUKY7g==,iv:N452OSPZ8T0B3NoOjGs0W6cRoEbSTRnIevfvrlTAQys=,tag:A2ooGQNmsQ29KhvgzgwVGg==,type:str]
+                status: ENC[AES256_GCM,data:XLHaOhDfWEcGQHM=,iv:7XjEsDFM57YXBub8bWUlQ1ib9+QXh+27NLxzkod++8E=,tag:L3V9y/HbpW7oIuWgLMpoJw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:TNgXA+/y3PYplf5QKiAFxIs7rWix7Wk=,iv:Sk9fLW/Wwm2rsM5LxccAuexvYbNAeXf1s0oBN6NimbY=,tag:01/mm59F8jdj5RDkgHY1pQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:F9HJsMc=,iv:c8CvOLbzeIag4OlFvdnLSnvKIOvosnGHnrDMRJlmUNI=,tag:jvX1psAiee/N5qDggyNekQ==,type:str]
+                description: ENC[AES256_GCM,data:cKvfCjop7sEPDoQb6utmJUjIFH9FPqbhpjzTehEiq3e7TQmYR67PI/yv813gXwPG+rfAJZqO8TBUl6XrZbLeUw3kdBQIqu82PJQAEQCzOD/a7EBx6qHr+tCfuMIBFaHCNpqqtfd0THcuDYSBhxV/VM99Hayk6DlxvPha7p4IvZKozUbHSs/TDM5X+Sl2zVH7lpVyyZgM3s7jlMlOswmT1jza3ppV0OKeYu/rPFVnW75C0p+I7dx1xDJrU48SNkXgb1c2LBul/cL2+lXyy5q3m7GLCyN+RtsNedaozmj4pceQd0LsYgfaVhY8HtnTS+uJG+FGY+tHigzcB+Xngi/46HrFLp6Mxf4DgMhHmPbWdO0UGN8=,iv:1yNuooS0Fy6X158Vne46zPDcJhJPhpqQ9dqte/lDqAE=,tag:+sZ9ZR8lpc8xqRWaJHdqSg==,type:str]
+                status: ENC[AES256_GCM,data:hA8W99bxOnKUXAw=,iv:XwfBeEQ0UxrISjnivLGIST5cLR8ICamF7pv+jhbBZkQ=,tag:ttv+EWXfCtosWJHVNzTnsA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:yTVRcoc9AXMKHrJb2RneElFy4ZLKM8QsDehMwg==,iv:ax0Il6QUGdQnBCIOejLn7We7rIE08tshZReUQ0Ay0lk=,tag:J1n1+BhOGE0RKKEO0564SA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:iaUD5dc=,iv:fY6xHh7GvKHJpb4Krs7nZvybjF+Cnq03Umyb9vt666E=,tag:XGrC/fYV9kFIKq7DqcmI2g==,type:str]
+                description: ENC[AES256_GCM,data:NbnbkYaJxJt56r5FlPwitlCHmUu1nWCfAjR3WxIZpok77Ux8FJEH0wVabBlZdQG4k7ZoZDzyxAEBrsGPSwsTBPNTslUWNaHgANgj24RhpCmsvui6ZP3+TZ7gOceZQGEm5hGkgpFe6RVG44apqbwJoeIDzN/wOU6UkCTvT5vNjxkLLN8dUhE57GJMxuORyL8HmYEcKV6sKlSpQpCAZUZ++AZhrordAOAE0hd6iOZFBYF2NKC3Z22Yq9kgmHaPjaCeZ2xcwwLAzsMzT4XfEtEg/E5KtIkWgpU5cYKv4W377R3c55JN3A0iH5SQfXrVU0IIH6mHuV1ucfhJJYxEZBV/FfXRJFpky6g=,iv:U+6Zy/KfAlhmQLaCSVGvNfyLhlkGWXtBdr8MxY2RBwI=,tag:+rJIANztT05EeSUnyW9bHQ==,type:str]
+                status: ENC[AES256_GCM,data:jkv/k/PIOgZ4/wg=,iv:DhXYkCB6dGXZd1l2z7JxOAKt0dVSm4h5hVu7XQ620j4=,tag:bY3aWa0Of4qsJvZo2JHqcg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:KZ4NBWFYxxEcwm+ojYkIBQ==,iv:JiGhE2IoahPtE/uDSXBW3YPZzC1Ro7P3dJ6XT2qTDlo=,tag:xUF9k8/I/S83IoI0M3Q+xg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:nXcdOSs=,iv:ETLcqcLcd4fK/QiFYFm8U8an08n/+RgzNDZIvad+IkQ=,tag:o3yfrEZPNgaP1baSntkjjg==,type:str]
+                description: ENC[AES256_GCM,data:WLUXxvSm0aAFCASyQNTFLY5eU7o7N8DIxl12N8JOJy2r/L/f4jEjwmzGcE4cxsdPkHlbbjc4FV4WOwni+YZwRy9g7CVtkRg04Sgyf5eoBkwSqFATTDrIa8eA4SkqF6Sb2ic/0xVAJ41ac1MxbQItLJtCBaDQHHQcUM/fdcJHRsZ6cDlyKC7QrAkCZaA2p3KLlH8j4sxZk7KQ2nOLh5qvIetpVJ8CaVHqvTRqoxEGg7m+404cATmEKoz3iT6NjOYMBFotBQoOkzgoRr8ugtaUl1Af6s1S6TrCSi84B65wB+XGyghj7tzVo1Kqm2ns2T/3lpvHO6lLzT5m6RscgCzbtpKvgikEM2R9cqQamA==,iv:jFi4W0ALjQ+TQ4qa+sufB9DjTHlDyfL5gSSywNrZ1Mg=,tag:AkZLvUf52AmUdUXk9EDARg==,type:str]
+                status: ENC[AES256_GCM,data:LQtwCHEjuT9DoBY=,iv:+PSehh2Da/7Tzy1scIDx+TeJFI+3s/WrHBxWiEF8qnY=,tag:HWWCvG6+PYSZu0EhunaqXw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:s44s7iCtAVTOmlQ45k8E59LtaQQe0v4=,iv:I4rIhqcvsML4GLGP2GQX8wI4WiK2l5QWKHI06UUHjqo=,tag:qJyhP7DWZvfbYWmzCBHOoA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:mwADEy4=,iv:fuKJ8CmgdmgAn8YcsDArGzV+u+8pXs22v6/N0pUxsqU=,tag:6Cv+8s+tBJGE7RsEuQf6ag==,type:str]
+                description: ENC[AES256_GCM,data:n5CD960ka7xpKzXxRSvGPv/7vD7+rs0QrLw05U11v28m+qRCZNx5cm5FWYLN1t+IUh7fl7z2A6jJgi8BTo8FZlX9EdgcWu0ofYgsgyEJi2vAvoKdi5Hy7VRRKJ0DWge73Ll4IySOgT6HqgluBzLCgWFIaYYqANoOm3+htdTBoiV1RsYie0QDAlySyGRuWAHJYc5ujdcEt8ICY5FiRUgECKLyLshiPosGeWNRIl7Hwcm6LhHFvySgIQ==,iv:5el3fjlS++7Q0mE+EOTGfR0ALrKeU4c/W+ZICw0hu8Q=,tag:3NOOpa+Z/FnaDWdsKFV0Ow==,type:str]
+                status: ENC[AES256_GCM,data:Za4ytM0//4r83jw=,iv:76OxqBlqhjEYg1qD/qPV7C5BLVs8VIiENJeuB+wap64=,tag:fhv8f7LJYKm7Dt8Q2BUb8Q==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:gKbdrsI9kftntGQjeIVEMxhaP4+Dqo8SoxjwK+/evw==,iv:miiyrwlHyEI9XwJmByFy3scJdy0cqYqURgR8/sMkrmE=,tag:L2f7noaS1sVCPdftzDKRYg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:cbJW0KE=,iv:BAX6ZwzIBoasdGZQsi/Aseb807fuE5vyLzx3Pt6Hofw=,tag:+ewouFQ7nmmn7Vsgr63fVQ==,type:str]
+                description: ENC[AES256_GCM,data:wHrjKWY5mw8ZPTow3oDOEWkGFenGkp21RvAYgnO787S0RO74gsaVX/eJ5QfxvQEYWPvztTh1uum3IC33u24Ch5dqRig+fCKaZVPlH73MaC4JKD+lJkoECX46INc6472QUx42+huAG85yJtMmoQz7cU7VId510wGUuRWvQjpYGi6OkpBc0SKgw2JipBeJZCukONkiYVw1VYk5FtK0lZIqpFuRgr//0gi/GxGUQC4EVo1lFFbOUPdvMS2y7e8FQVBCsGBLgVLU591I3iUhxnv4nDlmCzOwRYR4RH9Qx6qFnwelo6zJk6mltVpllcjzigj2w0eAho8As+lZY/6XDMIRMtbeH+hNHYtWHp5EBX6xEaVbJOvFcVURadE4Fqvq/AdHIzWfr4pWZE97z3BteYZ4VRLQNZxm0t5MzpDPSsGch+BfYD/7dsoV5oQl5QmjjukBELyghAh8/tWZBHuqdWH3zV6igDp+EgmXo5hvlTp7JsOYtXHvys1jO60IM3PQwcE3iHkdXpGH9EkSPSj410SRUf1wNwBlzAXBbeUJ+DaFYP7kBqtuh0nnEELzAnalBW4+rAQS1NQ7NQlatTXQ99vKXhkmCqdi46sdMQ==,iv:cPGRKLSAV456sC58wq4BObPREmzqS0teGn6raaBazQY=,tag:JHeqUllHd0wlD3OK6J0Ifg==,type:str]
+                status: ENC[AES256_GCM,data:aPOxM1eOW5iEGIE=,iv:Vmiv2kY+pC0LwToRwTA5bAu8B6rhlahso5ANR9HCHbk=,tag:SaJe57TCk42an93gSqRU7g==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:DXrD1R3v+WNKrcfacFNjE/rkQGlSEG8s8HKynQ==,iv:w9Urv5n0Ic/5p6xf9UfNVA9UTyzdDeEEgyELd4u+xjg=,tag:3WoGS3rxdtQWWNM0b/vD1w==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:xnWrlyE=,iv:7XImcFgquwTDewXSg4pitRCtN2sui8mTr6gqUy/u5/0=,tag:62KFGAwl5Rvu/wT3yQUJ4A==,type:str]
+                description: ENC[AES256_GCM,data:t8H863V3Z4xoax1ADPEEPB1tVtMoKfzAGUJ6x7t4NXCo8H2VE73JGR2Yz5CDb8y7kFIQMveNXdzjDlFkb3ROU7OwC47Om5hWj8H0BrFwHZmhSXFrymR4kWEZNGYHOk2ZmwAhZoPzsLSGHeNlaBJfpGxwXCHwyaGn+ismfLqFLXH+y3lL/fT/PwaS5cAzq9hjCIjIokPqlmUacnNBtyPdRVzIxsJLyd3CfLs/5f9aH4vuzEMiiJCxEbBgEvI1M2WAfmz+4wpFZljsELpaiw==,iv:mqWLWhiDIVtgz26Kth7QEYKfEIzfiEBJmWpWAWnkGek=,tag:PSkmDgT/IeKLMjqKEVydMg==,type:str]
+                status: ENC[AES256_GCM,data:Eznt6MQ0nPFvvuo=,iv:vSNi8LVO7Pi51kHGuITW8mb/ZoVAfQwy/PvH1ltwbkM=,tag:EJQuxNZtjhSfhy4WABLuig==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:u8/cJRtwVkFWONN19opmJO8lG2DmWfIp5vRFIA2S,iv:mJ1zCjJ8WXbaGEcpp5YILLVySbJmF0Jzd8eBy1sUyJY=,tag:ykm3Mf7IUvFm6tHT67MR0w==,type:str]
+        description: ENC[AES256_GCM,data:gjRCEyPGjsXBhVsXAiU6CU0TOCAch91oRNkh4gdcpdV4mV/iLlWwv9HRgjq8co9uihUgvviUzbiKqY7+16bxalI5xyLUCw14e/VSg3vCIW2JycLWUf49hGZXPetSeuYvs1Tw4HHwd+fxUIQ=,iv:MkT27RpAuDtQkcIGExt5NWjMi7ua6bUdHqPm6K4Vd5I=,tag:AJO4RON3RQKno1gpoVnwKg==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:p4Q4mxlgIw==,iv:0GKq5dlAsvby+bGcdb+p0NHdX5vUzeigpkf3Dc2H4kc=,tag:dCyArPq2Bi1veawY8N478A==,type:int]
+            probability: ENC[AES256_GCM,data:T51UjA==,iv:1a3Hwu49Hju0+R4REIjy/ru0DiNHL4B+hzOhAN4EwxQ=,tag:8cwOL4M4Z8+t3TL1s2YNfg==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:uS9ePZ719w==,iv:0VhQQuX5qA5jocpbO2x9M7YPRRcSC8nM/fZTcdQEkcE=,tag:rYB7/yODBmjcZwggg/R9Mg==,type:int]
+            probability: ENC[AES256_GCM,data:nQ==,iv:4J4Iusp9ngvetRzgSssGWxcGmYXirpYzYcoXXhlscvw=,tag:znk6NSDOdtFAswM+/PYEZQ==,type:int]
+        threatActors:
+            - ENC[AES256_GCM,data:AeYMeWmaEw6+tMONLNObZdo=,iv:/bQCMJOJiANBRJf0enbsutoVcAMNdiSQlUF9vQUYyro=,tag:gguWVcYGCX887oGVg0woGw==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:UjkVAN9YJihtgQiN+IkEGQ==,iv:Trc4VG26GVJ0h9tZFjPfwVMBuyGu+ARQnrZ13iGirHk=,tag:WeYEWY80BoJMmRkdFRcYBg==,type:str]
+            - ENC[AES256_GCM,data:qjOnsA7P0y4wjKBUMA==,iv:ywvWzt91LWNLo910X/JOqzrzrkr5L4EkEyLYGJyPLCA=,tag:NRU4HG/lNsSsn1qoiGmmqg==,type:str]
+      title: ENC[AES256_GCM,data:BXCxewRXUG8r5iubobF8EPkfmq/2abEPKbt4PmaLOcXulr4epujKJ/6JNWbZ28TanTwQZ4ZiDQ==,iv:jv2qgTzo5B+WQOXWoRf6SntTDx5Yn0sk311RQM3xT7U=,tag:muTOrGSER9S86Z1Lfq/2rQ==,type:str]
+    - scenario:
+        ID: ENC[AES256_GCM,data:PHYLRu0=,iv:1O+CmL1CrYNbVWkjzPWB3sgn35ZYiZAS3SIMYGCHWsc=,tag:fCirHynK+Vmrxi2iwUVyTg==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:e8d91OE=,iv:KDyKJ15r6sh6A12uKVbnJs4v+YRlo+bfweWWfSpu/S0=,tag:lHM+gih3Idd6Ns0EUJQK0g==,type:str]
+                description: ENC[AES256_GCM,data:0EVk9K7O5kRoXztSPdqo9suL+q8U3RdoMYpwFPSBMwtrYmbmVXVvD6ApB0w0NysOJyi5NqEL4u560uFtbKqy1DI54M4/ugIGreEKbnLyXj8odlKEcFlWqYP+DVqYkQn5mKmXrWKELs6J2MYax9uZTHBVzvqPvo14CrHM0vNrXPuo7ts4dPgRSG1rYxt+Ns4HSH6hb01++eT/ws7Vkl6sKM97tIPx9ONnxwlEipgdxDkmLYK3fei+jrOO7v1n2fX1bmd007yj7rdWUCGIGEjhHTzWXCor27Dw+Ju/RGX748301fCUmPNTcnBc7rA=,iv:S9nLIJ629hf5vjTre4QBXf5TG+UGDlVpslSNXNDqCY4=,tag:2nHBcKZ512Lj0SoguGQSKw==,type:str]
+                status: ENC[AES256_GCM,data:WgU3crIru6RAp9s=,iv:+hdzZQtPddBxJUH+MpKj4uYvlDqOx1WeYF2CcfqaOdI=,tag:u2h5V9kAesnBrXZz8uJHFg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:PJZZhHmXEKhISbB762bZ5YydojfS1Q==,iv:D1PwxvbxXueDbk1M/RNf0U8i61Y+WWeLBkXsO2iEGRM=,tag:5wgCf34jR9a5DOwH/JpYqw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:yvgiccQ=,iv:tlyNFJklClZ2ibY3m8G96m0AetL5+QS3vmUfkIG+8EQ=,tag:J1lJod+tXKUiPpZTThRH+w==,type:str]
+                description: ENC[AES256_GCM,data:3O73+bk1CI7yOr22X3dRi4X0iS8NExeVUQ2ZSEduqIeWrk+hHkdha1Pbb4aDn5lAGIHEuI+Yn0VEeV96U7ngCSBN2VdFrEALrzK3RF7ppnV/YKzGOw2jMLMkq5N7oPy7l8FJMERZhSFwA3TqVxqoU3Fan87LGRWttu2OGvXqeCmb3mNtQkSSlNZ1xIMr3hJcclUhfQLj2OoEKkb1NZM0QtIuVuCUQdvSxWP3rsHcLCwKaBNdfgew5iuelXdSSGJiZiXVokoRhZED/tj6dQm1hJcWYIYsPq8ynIeMRtT2g/8GxSjkKyJALVDWfgBZmEhbf8Exvxt1e66uaDWYLn5qgpnJRA==,iv:tj8OepMQOQe/GApgBXXRZNad647+McBqk8YHT6iTbyU=,tag:KFLhE8iMSIVxYunH5numvw==,type:str]
+                status: ENC[AES256_GCM,data:M5a42SI+MGzpLWg=,iv:wE8fQI1XICekv/Z0+UhRHo2GeW+1ZD7QpdpXTWsOb/c=,tag:ySwGTYp2h3HHP3BaVaoqeA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:l6D+h12cs5IJBi/9PlmzGs23IlR4,iv:17BypxTkwlsQ1gSAFGgjHA/4rCF+0qsks307hKSmpyc=,tag:4uDnpAP6ghhi5F1t22ptyQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:E9tyXkI=,iv:/1+ccv82BWb0KiiUvEa3ut61YZCu8hWuYALIZP7Z8s0=,tag:Ay10Uu+zpcyNkOcn/i3AIQ==,type:str]
+                description: ENC[AES256_GCM,data:NxkI3nAO6btqrlD07mYMz15U9Tgk1T6X9+/D/jAxuD1ZTxetDyv72B3G7gulGxJT0QxZKgTTX36QzxD+N9BOI0oFDPSXFYHPatbUr3tV9CfeLm446wLEKyDIwfv7ZhQgOyjnkB/m5JnbtnZkIU6Oa5ExRyhTmW0kR0FbY0X5EgmsY6YHarDxqKuyXxMnWsS8pnPPsQnF6iZfqHJDCdstb+lplXcKwrbBy4fVqnNzPIkUZcNYohiv6vC1XDNDDzRaV3JHxWpwDT7TrdvHIKIgSyG+Z/IgX83hZmlgVfNbno8kxO2PjdfvFguobsLR37GMjok5vtWDs+2PC2D88xJdbzJqQ3tUDwfyvEgM+h+RyICDVIX8dPTZZ4k+sMpOQsRXB/RlEelZWGRKaKnNZG0U8qak5N4Ec6hj/PQSF7/HXBVw0B0Axkke6p+ZuBvXUqq/0sdH0lf7TZY13JVV7jwp9BOoD3WxbWOw4fc9jq/bQMGsqaDtST4fMAUKPM3CNn6CX4MeprgSe4DTjKYdB5z4nAVUjzniGas4/gF+IWVfQ+Rgdu34Bun8KWUuI7X4klzk3CbUMrpI4rCSrHEg,iv:J6NAPGRxSvQ8+52Mp25hGJgRyTIbqPS+t5pyzB0OIsI=,tag:yclBhvJcZQQqmP9HziKitg==,type:str]
+                status: ENC[AES256_GCM,data:a71Sw1hZ3IcRR88=,iv:wuy/lEYHOCso3OwBqcqv/cE9ObHAaHhArM+JBrYu5tE=,tag:Dx9hiW1inyv6j0tgcrTOmg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:/WKLc70n68JpEaNPfXWrW6uhXB1Je6Y=,iv:igF0Eh/AqKLwq7Zruyh02f7TQl+vmBOLTSM23/1htFI=,tag:YIrbujHNh4AfZjTNuidE0g==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:RLd7qTc=,iv:E4NgqK8QAXqrEKb1faecFHZjn2OHx1Wja/MsYDYrBB4=,tag:udEWlgyw2UKwuZTlJIV3fw==,type:str]
+                description: ENC[AES256_GCM,data:YrgXY9jBXgPCtJ//tJE7mula0dpqb0jNI2mZBhuQETnFdr6PeUNeZ3ieLjRGKsAjsBzmGqY+nkiwwDP2Xa8QcSRg2NBY2Acf7hOjrE1kVDLIxzEPA/k09W1BFsn7CX+5l7b0S4+4gOX7xRk9Z0/RLcdotznO2MFdViN3uPRBoI8UadGIwqN/w7lh/GW4HV4TUDuuGfCd5NfX/HEsB+kTDASXxpp8/g+AdyIjEQ7edoWANYZ7IV5eR0uKHuFM2JAdoXM/Fic6jOw6839Fcy10bPu2V9WALZ08NJKHnHenKUTAyLf6fQmbph1vTT6KgBzH9GhGCl9iAfNwj2q3a1fdAft6wWiiQbBd7/O7X9HQXaEE63FX2FOhBQv5lI1cPjNnqI3lCSpaz6DjvusPeHpP5XzZILXNowRQJNXikc80upN41gkZOAWCzpiWhsypk7hnOUV9zo7N33Qm9Jm/myLdwkomi7d9ItVQr04iChIr9XqCxeHkAT+MjlEAh7u30VMN6VIDjJlEGbPerHVRbVBiHO/Su7Gzm2xl4O1bChvsSsqLgDM8ZBJIirqIw5fkXQnguBVyO0eBOA4HVaDMLgZj3rOjzwzWaNlj9CDCG0qZGoodVo8VVmNonkV6iKISQ7lEeYEDSv4gWsGYlxALyLHNoxplptauHFqCGi2gdF1mk5QSuGs4NeN9C2XkeCa8Z1VTo/jgMOEyEzQ9E25AMk3REaJT/um9PJKa9U2HLIko1Fp8ZQh6E19zf8paRX9m+8prJ+5zaXwRUEjj2WBx/+JIdajYyRSjvLJzuczZadiO1573fwgRYYOAznKll0ruwY5JoRXFZfq0+V3woYf0pbFcnKGVPr3boc+cC3B0Zndis75oN4BQC+NEx1SeFshmnhInNNmvg0/ELLjHFL0yjPmtwE2wrgz9udR3xc8BhysWQMJelOu82+xykYADrVlWWpoeaTKeq+92rSgkEVhMZzbVRmpijZwNumgIOJP/LfBK2B3gM7N/hIbt6wbuvdj8vNVG3zaka2BDgLOpbzX3iD953Q==,iv:p+ajWLam6AkNUruero2is7JGmG/ox4LAs/cktEVcGT0=,tag:qma0fYYdKMhqKf6u17f16w==,type:str]
+                status: ENC[AES256_GCM,data:aReetOsXMEJCEmE=,iv:qWHrbsmHNkz8Ryeo7dVuzlozjUlNqVubMAcZrgMv4XI=,tag:y7jOYxeNyNSPwurL2+vjhg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:ljPu0p2oy58K3PeBiUI7BRTIDXo=,iv:jlVs4aQ3QHRhSvM39/eoCfqjJrLYGe4F5VWjny4culQ=,tag:jIsQVPQ4RmB1/ydMw22qbw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:aEJFc3g=,iv:bueEeDHO1J8rB3l9PHGP0+ivNWdykBSSNwGOmIIV0EI=,tag:r+v8UZ/ha1tRtGPJOf6BpQ==,type:str]
+                description: ENC[AES256_GCM,data:qifQa2cf675wMsXYImeik+YIWp6ynAg9LTIdr45002GpgjG3DOwJTNWV8TjbcUBMs3HZmpCaykT1GUz7kNryrmQXPQ/ELyDD721zDoSApDydckyPZVQCWWbYT4stxOFhfqwPfQBjIJ8DcTZNRcTMDpcQQujI0yaJs5+sGwXJsceZKKuZYO7TPifWv2Mq+HrIMBCdSSymRVjfUEpoUqj4FBjJnD0nSjg77GLUGCvwvgbI1DL3Ebop8XrmzIWoTjYwe9KIvtQTx4Od9eDruelBIqWjypehrdFIUyhsZGTAsTk8ND5htB3nYrGG4NhnLwq9sXSeJsTiZnL3g8tNnemuPL7Gp3aaHTUlJUPN5QVERkrsU8aleOL3EOfRN84022cvzVc15Jkg8li69z4TqO31VqEsDuJP8C+ZKHHRsgGCRqAzIA==,iv:shDtNxQOMF7K68cvCDAioFI/2Ve7QaudQwiq87/FAoE=,tag:dqcJryAwwxh34xcgyguM6g==,type:str]
+                status: ENC[AES256_GCM,data:UKKVRfoAdsOHaHA=,iv:8fjuattjaodMs/aTmxwJEXJKolbgVQz1aYGkUeTG/Q8=,tag:KYDZr+WOQ9AL57oKtGPmEg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:8PCz3BlikuK6uYj3ZwJxUL3BIg==,iv:BcyK5aja1dzfQJgsMVRqCNKgx6d3diyqkORKkidfGVc=,tag:VSt/UewS4zEnrv4m+3xsFA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:NmZpi94=,iv:1D6hum5PPmhW9Sgrqyy/R1YZ5X7gLC0snT0+8YbNErM=,tag:tUAapOuCGwzSxUamxf32eg==,type:str]
+                description: ENC[AES256_GCM,data:azAJGcL3x33ARQiPg1+8Ki0v///55OKyNXGkDFo4XATpBs6EkTlWw3M7qUf1j6/uf8SPp+0BhtC9BAIandSHyZWzlVThH4Bra/tDHvA177ySI3eDoH2SOR2hmEQgE3nNxpBi2cGtC2Kx5Q/RhVQ1qpTQ8YZMG1zHrgmV3BPgBt/C645/WOH7kK3cLRQ/APv7bOYAC40MeezLyySjdX6zVAzZFg9Kt7fkgkC+IewJ2Fx9et82DTUa4WrQlqSPX8d6JeWiDYfKiQNS+nbAjj8b8cHmkc213hcuFPeW5petjGT1vMlB6qRb7xeW66Oxx7Pm0GO8zwwRto2h/4sEnlNE1iSB4Qen3yKGdEQ5NcY1H+FCVcy3bbxcqk4Hu9FovD9iqBC3mfiy8ygYoz/ksbN23qxIZ8Be5gwLsSyYj9/rUQqrVbLc5ZQkwGSMBjPf8ERPm/hSVvrfgZ39mKL0ALFrFSox16p8zjsgINPrVULXsN1r,iv:eNdLEwcNjt6erWvHSmyAoZz5QL+RmzjmkVEHTqYFgGc=,tag:MpUTJDkMPSV7VaHRf+hP4A==,type:str]
+                status: ENC[AES256_GCM,data:r2RQbpOUdpUej8g=,iv:oA9oJ+bFAWn1j8UWSaZMW4sY+3DAIzHFDc2phjhUxxw=,tag:rzW3Nx9hlBkS3hEAgZ6QdQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:RtOpR44B+w1rIdKeqZSCOetGJBI=,iv:r0uMXT7dRkda28bIrFxKzIN3B+nf0Xo49hmGlwSgsAY=,tag:6Nxn4QD3/0tzBwhVvJgdjQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:/E2P4aM=,iv:TFW1RMy9LlGFXTg/bIAJXqYla4ZbrkXamp2RUIx50iU=,tag:WFB/jMY4LlS3EUbwRX93Hg==,type:str]
+                description: ENC[AES256_GCM,data:zKCYBXFtt/VgliljCLJ9O+b7XOWOVlCen4Rhp7Bcr2jaTKFgbSWsCvRvZ6gHvTceVjl7qsJZd6uRUgal1lHN95M6qOtZ3Ct+WfcLqdya5OVbIYc0lez2jRhXBrwDoShGyvJnX+AT52devPG4BVcuWXZdtnIy13XvsYbL5sj6T1MwZs+OmYiUdJ15UwJqyPelsyfLyXGbDmzPTnrfjLwV+eFuA70xovXbFFG0eocgIwN+UxZjz69wnnJyviP2cQ+dXj0ncJpCQlhrqwT0Nhzd6S3x8wZI1yT55H8QjVWAequdjcdwUQ/tjnBEN10c43XFZzB2MqsmZ3pziFTYKhT4jMn33ebgD0goX9cnES3sWR2qpM8vJNDiScKDOdPtswUzMruFO2/gpbKuTvPQarNRHMf2DyJkcKCc,iv:CoOawvhW/peEYXHvcPlWKIcVKPJl7bEj50qeW9nAypM=,tag:KGOPH6Zp8UL9aZH/ko66fw==,type:str]
+                status: ENC[AES256_GCM,data:80xg65lSEhFkA8k=,iv:2nBCUjEY+ICj+Etk0IBZBjUtBu+UACghc/rgTh2Zqg4=,tag:eFNPv1yk7bIE6E9dtmG7dg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:4iAVX/Zs/tgQ+BLF2DkwpQ==,iv:VQNJPyQwdKR3wELgLXczCDFQkyDkAZDTOKG6pen95SA=,tag:YLP13h/wyGzPbJgolmyTZQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:WquW578=,iv:ADpttjwakgdAxxAMozopzBHSunWd+UUJgDHQeRRAy8M=,tag:fqreE3EClT8LA7tIU+KxLA==,type:str]
+                description: ENC[AES256_GCM,data:y576/nYk639qPJglW6H6i+40/QsMOvRxOzT/fG1ppZkXLAFaamrGN591KKOD0TiuSxKoWol94tRdpZRqwWmT+39ifaBqoIsREvVlbVPMBaC30VGDcf64rzpif+rGliWN1DJ3DuPnm+RV88+51K7JM45QeEM9MkDhNQw2ru4Rfv6rDzti8XKck7t4BrDvQbf+5KtJS2fWZ5FyEYIunLRhotbziASJNRETLVaVO0UOyPERhjZ7DGDZrkOdM44/36840A24WyVAgWzOZQ8uM9I6XW79oI7loh/+Fl3BGraLh+CQQS1y4ybC8GjvN9B4hXbrJQQqQ9drC7FI8yz0OjmFfO+zwWZCWUmMB24xbzolId/aw/Hntm0IcEZX8/sfbtnLZdIs/8Hb+Mea5TmKTtYWizLnRXPOIcU06pyxaFyBOw6Y07CJDD8Z1Vl2MNaSFehjUF0CGPXPw5Pbc+VZmg==,iv:9pQJnnNMJzoay2g3+EzsEOkh2i3dt4+J1kVKMle2D0Q=,tag:Z3+4ZgSf6BOwpnn8OT4qOQ==,type:str]
+                status: ENC[AES256_GCM,data:jpjpgW7Bm9u1V+o=,iv:XnBTk3Ut2sb5YhIKBBjrwqY4VwzrAOm/pnLWrYkO7rA=,tag:fLUHsJ6tC4WeZ1VelZzuTA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:KttRrD5f73g0HW8h0YsgrtGmxo+4JAs=,iv:+0XQZ6NfbeXWjNWi+XZ5GKwRlyuxDk6oFbX+kSLssMw=,tag:qw6eLLRL6ueQFQ1iEauC9w==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:akwsYmk=,iv:a/qcHthJ+vQ6ptOXpmCU1VdCA+/RTDBx8lNFs0iE4SE=,tag:Y6w7zVhg5VJp1kotpK2BQg==,type:str]
+                description: ENC[AES256_GCM,data:LX0x7DmhVli9FhsROktHgdWZsrMn+FoWWsPcVVxP4ClOJ7QrYTDWhcTKCJ4bfHj89PkP7ip1vVbnEW6Z5xSq0ylAdMRi+BM18Bl+dx9tPxqCQPVu6pMDHuTKbHnuxV3PNLPdSRwZnrpw0fbViqLkcRbIRUkA/8oT9lWmnrRs1haSk+JYN4VyscBktg/XHew4Wq7YYzeDTjLBuT9E24cdTcBYoV0MYGYfTqYzyaYwHJL0Gyb1XDLL8ApGR2sAEtTHiVwLnJ/qY0oON7ZWqQSc9FmD459T3OXh0oJfEfbUhSz36eSE8tH+aLkNdRNPDGDPDARN7/dfEOitIhI1oCX0/Q5bbZYsmvNXGzpC2dXUnmPI193zYjD/oTCPxzdAxH5CSAip88g/EMW63i4/0l6LOoZn2sTL98RcoSrqKGpbmA1Lwh/Fg9vHaCovUDq7Wt696eQ=,iv:RMUyIKRWUSDbn+7un6EsWEN5SCzK1Z/xzRQJ5zY2yR4=,tag:9FZPlDR6HxAH/9ISMtSHzg==,type:str]
+                status: ENC[AES256_GCM,data:bqocmBdu06RRqb8=,iv:1GQ49E9HjQbpSk0RjoFN7GdTH0FnUAKwDm0O5effnFc=,tag:U+zbWGuQ/dOrrY5ijfxM0A==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:S6YGEOWUlk/KPxLVNVo0YjI1Ny1fiEc1lQwXqRb0vbA=,iv:J/n9c16TR9ms2rZG3PVZxYTf48ly3WP9NSm2Y+W09T0=,tag:ew9tpqWBF8eeGrbIa9kq4A==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:valLncg=,iv:yXJwvVCX/HNGVdJd6RIWvW01GDeTj/DoEX8pclZKevQ=,tag:UnXTzVqDsY4i8IMaRv4tHQ==,type:str]
+                description: ENC[AES256_GCM,data:GRe+HCMUhXzMiNJN01fAa8qAdZDqh8FaJJTCXXGotkIBVfgshmD/zTCx5v7mrPi2otTykig1vt0ysoPVmhAxqEUq13LsaIZ7/6/arwTZp9Y6Q+aUWHnVXaY/z/uHRxPPFv3y+avAfb6DThkN4cNuPCqN8SEk8eQ3ooNPcH4ZcdlmyEFdVBuwLzc6r+FmXDGN0pkbbY1l/ho/UNTaOhxyLbv6U7Nzub2XiaMxSq1udXLwrQgbnCyucighXgG1FXLPLfWvFVGtuG3/WfGcC/08aWaimNUxoEZLViiZCfH4ORrA//i/L4xAsLMWoqgWJRO7+H3LBpfAturdv9QC4A==,iv:mw7LdDfonxUw/Xoohq4LBnmm636tMeO+i/g5LvYZpGo=,tag:T/REV9QeuZfBronc4JQ90A==,type:str]
+                status: ENC[AES256_GCM,data:xa9Qc8v212b9Z5U=,iv:knAjwTMFVAD8FwMDR+8kbMGuWV65VqL74gKv4msS9Wk=,tag:nYiIB7fZBUgpXIkt5tTSLQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:4xOm0XW+Yq0KkxhOSj3O3JMhxKReYolhZru7,iv:M5d0JkWaAWlLlGxn01j3VQYkNQR3+na6ORMh/PRyrbg=,tag:k73ZL2g4/hTNGCecSZzmDQ==,type:str]
+        description: ENC[AES256_GCM,data:O1A49fz+oT76uSdY6gQmAo7cob+Dw1bfJa0t1B067B4bJR5ewCF2Mi4VyCmSC5PnoFIbsbxM1mNTzMCUOmzALMxL5vppKDGl8KqG8sgnwYWAkP5EqpzoBviuYB0EGHa6,iv:t9UqWGqn+MrT+46RxOfZ22euFIBFgSo2ZfBUn9mxz3M=,tag:SvdpK3kGNs/ZmwWnFjGqCA==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:HFY8TDI=,iv:RI5mWdB9rLw1FfiA56ueuZ5t8bwWhpmNJ4N1D7Eqp4Q=,tag:d9VOpeZ7dcjgWoXTQYzHSg==,type:int]
+            probability: ENC[AES256_GCM,data:UCnpDA==,iv:3Hjxy0Dd8DzuW2qVI68xjszS3qQ7hOwY6pBNoqmO0/M=,tag:nCCcKCTxAn22Ndx6KinZtg==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:3cW6jbQ=,iv:OchzlbBS1krWURnetnRU35JC7EckBd6u9HHs3kaqex4=,tag:mpOXmsHNj+bFKTPU4E/vhQ==,type:int]
+            probability: ENC[AES256_GCM,data:8w==,iv:5GKouxwyEmOxL3FU8Le0gTJPuY3MdZRD750dn1RlGJg=,tag:WkpQa6dNmpg074ze0J8Ijw==,type:int]
+        threatActors:
+            - ENC[AES256_GCM,data:Rjoqj6zf9yX0YXaJJvoX4pM=,iv:8Hs45jdi1anvLmv5Ri6hDr0G5xqc1Wd0NBz4mRXgFXQ=,tag:s/06T7Xs744XYjhGnGEsWQ==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:csYBvHJEmOaf8tVZww==,iv:BYHVbLnItXtzO/MURAQe9CXsAuNwjhLMnpbVi4/m5w8=,tag:G14YFeH6C4+BUYPLwR/CUg==,type:str]
+      title: ENC[AES256_GCM,data:v16VCHQDGRbDIMpT5oCDdQOW9qGfDZu0uX92iu+ueZvUWwrZTzAnFxQ5OW6O,iv:xlR3Z9iUQwhBN/F6fWtDBGsbQ/JYDkvQlcgvo/PZbuY=,tag:6fRdEg6A8LO0dCqSXcGZNw==,type:str]
+    - scenario:
+        ID: ENC[AES256_GCM,data:Jj70bPg=,iv:NmCNObA+e/jbrGILxmVymCwUG6CjT+HSg5MrYzgxv/M=,tag:ZKThsFqQ810wZ7MhwKPJlg==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:MIZekAM=,iv:KZaXpX9sB/iLLaBUyEQMiPT4iVaUfPxQfrkmOHDKAq8=,tag:3r5ik3RkOM2b8KGuds+ICg==,type:str]
+                description: ENC[AES256_GCM,data:AG5RKJUEkpcY3PNMYJC3EngPGrcPiOPVapIDcqPVCV6zkxgVdo7wE810Tx1ThPaqraerCI9j0zOAeKudnNzZkPt0o8tHfRsFXlQdNNHR5z7uXTac+a3vJQIIEOGvxG5VY6kwm+G4tCiepHd8UCM1ep8CEMuImlgVgxhPJuQk9oxg/Ecnlvm1zmmSNDXEaP/BqOq3iZWb/SA8UfUlqtEoI/MbRQRdDU6CAil8QW2Mgpix+VksDuYg20JNZIc+t6nQ5E1iXEMCq/N1Z53WHqL5LkHyHlUxxCKyyPmcU2rcgcmx5SsXXBXs5yIK,iv:g9x0C4Ha/o2OJxBca9bwon+w8l7cdXZ3iUwB9gnUBU4=,tag:c8gAYvN/B9qRigPTUX4Tmw==,type:str]
+                status: ENC[AES256_GCM,data:76PbJToFWimJFTw=,iv:zzDsx8ITTe81DUA/JejUhzGMqRcJKJnAAwy2jhg+yv0=,tag:mXIuoR19c62MW33VIY/Myw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:eFivObumSLxJUc47TRKbBYEfF9Lr9cdF6qdu,iv:BG63vIoBwIHFgw0yCFjBPM0aY7fbxhNKusXUUfpF41c=,tag:Vxv7mOSlBbpLJfKsqUFMYw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:trf1qiY=,iv:oHTnH/aTtk3meTbvFzFVYgBlOwUbnrJ6exPXBmfTYp4=,tag:9Gyba/4t27jlD0wWIrsGGA==,type:str]
+                description: ENC[AES256_GCM,data:n0NiCMQFH/OEgsbK80VXoOjOPmRMNkk9xkdqv235wo8gNd2ATLCiedHkIb+t9xFEq39YbWwfr5jG54LLYC63YmmzgFoSrtrowA2Jl0ErCv0bjkbaN5PBZFZ5FyOw6S8pQP+SKm0YBx4fatsk49ofEOfwIxEJbZtDmdDbA80wkEsjYnCG+ZL9Z2+PUO+Os1PaUANBeAG4+sePxbo348OWv8Pan3Gjw2KSYB2dJtVuCjCTmVoaWf6nvGRQJWfnRfSGdMB5kXUKQGf19ySiM5bufL0HY8zhvRw3eacbPOaup4X/Gi7QUyy7BQYd1MSoW9wOeVHiHDytTK3ES8JDkjEmXRR0vEiH5T3SvVq2X2ob84tt8+u6yhxF9FmCYVwI1xg=,iv:5KBPE8HTHQ2FAXXBhs/zaCyh4Ol0TXbGC4HV5rDCfzg=,tag:yWkfmWqjhBjMSoaYaM6J0Q==,type:str]
+                status: ENC[AES256_GCM,data:B1jWjxKTfFCSai4=,iv:esSfLfVpR+FjzhSojzzloa/WI7x1iXfpnHIriXntfq4=,tag:5yrb5WuM+KprKf8JOcR21w==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:jgmG8B2ygz0tCAoTpSXKSMCaoUE4Zky+Gg==,iv:sAHqli2C0sMrymUpQ1HNXO9me23gYrOsUD2Uqni9JuM=,tag:o8eRMS/Rio0RWOcsjUDjcA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:iZzyitk=,iv:xhnCgwNkhiXod46Z5SZ/EkO7SWeuKZCg0VdbJJmVaRg=,tag:xETyj1AcVxZnze0jybPG3A==,type:str]
+                description: ENC[AES256_GCM,data:7lRu0fziv61379vtCylAwpKu2/KMIloFuNYOPkjhu1u8+AILSBf6+zUJj7ar3QEZve1ExeRnHagj9iiiNfKOb+iPmZXmctVxHiBWugyFe95767Jm8UnyqSCpA37RCqQ0IgynEplYXSufQeeknnaBmEYzzHd1BvU4j1LwKhWvzzeQjfcsj4AgqnCgsZxKGoNicAcRui2l0ewg0icuwQIsCXusipg1Hgu5aYXmaDGl8uHikcSR80kCXQ==,iv:tsd2vL6KiGxhAqm3NU92UstPOkulmK16luTrDJkrNJM=,tag:y5L9pa9eY+9LgVmTpiI1ww==,type:str]
+                status: ENC[AES256_GCM,data:or0i/N04WZonylU=,iv:5YUzbOcSH92gtzlAMX2axZTFyvNEY00rNfmdmVUQafE=,tag:LncXI9REsssLR1exkcMUeg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:3ksx2KQKjTwDu0JD3tDSkcyFzQgM6FM=,iv:3IXO1a0zxrq5jELIELR38CkWEKZBkKXOcgXbFSztC5s=,tag:BruAlf7SZBRL+YRF2tQKqw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:QimZVSU=,iv:jX7hBtDenGlc3u4mVf0QQtgbPZHQcSypQFkipA9dSwg=,tag:YQhGlm9ZzTQ3Xheo5QHkjQ==,type:str]
+                description: ENC[AES256_GCM,data:7Dz0oFX2vRWKI1aS8TT9880suYdmxfPdy8DsiH0aDdNFoxGCzdDP5qJSS7kl+ok1pUs+bH+A1+BcbMWzlA3mRN8woNqfTVOAN6kcfi2sNAbfVR1g3kNM+FiASG50B3/JTrLXQzR1snunayUBnmDdgq5BJsTZoq7DdLb9ilNucRkUr8vx6xD7RZsSYA36YtxYqwLXRwWhGrDBxcOZM3iobmtQgZzQC8TVFasg0nQeJpYLfXn7Xk2fZuNjOebmdX2mx/INSxRH+rg=,iv:AqElQUW+mD0jRAnjYoeUsmrBp7gwvXEF87zHFHvZ8Zo=,tag:UjOMU7qMGoZ/uPxEXNvyIA==,type:str]
+                status: ENC[AES256_GCM,data:jmMBKppK5sUKRzQ=,iv:Q64Ninna2cr2zpIruYevyFlWl1HXlv3YFYfHjyQtYPs=,tag:1Ce7n/6Byt9TIghwCFvT/w==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:FeOl7qFs3mr3rm61cCiKcszsBNLtKQ==,iv:bWoZfX/0T7c75rYOBcnQzD9jnaALVKWamNZMBTY2e7A=,tag:1yWKl+Jp+PxDoDYR1P5cHQ==,type:str]
+        description: ENC[AES256_GCM,data:RyVhFV4WprvWMwC2nv0Wy/Exx4oGCOF1upQSg4D/zzRi5lYGxWKsXLdZBU5e8Fs7Fk+/RzythYnoTjeE+6UAVmf1CBr/iFcVtW4sQgQJnC/pgxUX4G2hAFhnCR90ld1VEC6iTYieQYxQZp6Z,iv:koh6chuamhabIWfgQ1ccj3aDQjNGoFSP1NrZALh63xk=,tag:mzfO4omLPQvxyFSpxcuOvA==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:GpNBEp16Ug==,iv:s4WrGKGQ/zJh9BxvYr8Xm8U8QVO6h59JVlePcb3/tUs=,tag:miD9rPufiESA8MUB3wiskg==,type:int]
+            probability: ENC[AES256_GCM,data:b85pUQ==,iv:nDdg1DvRcXaH5J2ccLxxrD/vgyQeCS4ep0ulu++nt/M=,tag:p71PlASA+SXwYPiK4ZG9Xw==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:g8I93rwTWg==,iv:y17rkV+jqBPh9F2HGhqxNucFNbzHYV5I1ANylncYUCI=,tag:r75xhEipvN35MiZafDTttw==,type:int]
+            probability: ENC[AES256_GCM,data:HQ==,iv:iTYwXFUMuC3vWaMNjeW8KkAkaBotpuzQSVOyrBfXaiE=,tag:+89xhb/PMEq9111lfLvthA==,type:int]
+        threatActors:
+            - ENC[AES256_GCM,data:C9eS6hKBqffgg2Ve2aAmIxw=,iv:TbocAXSN69M7qRPekjZc0csPr6TUwu3wOOThA5OVBdk=,tag:0608xYjR5ncvZld81MPQow==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:t5QdYpv66kQcV1L3Jg==,iv:gT1rHQ/HPhD06YEFpw4bgJ8KJBkbEnRBBk0WBV+QMbY=,tag:6zXQbeQiFLZ5bJUwfmqQgA==,type:str]
+      title: ENC[AES256_GCM,data:1CVCyDb4DeEW+5m3q2KALD92uZdsbwFFBZaiibZGqHM4hZEJS07k,iv:V8M6GrQ2LaJYSKwyaZzStccTY8M6f4zmnNZq8VedKmw=,tag:KOo+ZaRUgDfWuJoVqdvZHg==,type:str]
+    - scenario:
+        ID: ENC[AES256_GCM,data:h335eAk=,iv:bMYEeJ4HXSHte0+yEuYL4hdqnUm0ISVgxL1LmQo2qEY=,tag:JNrnddwXM1xz1NhDU69rxA==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:B9743IM=,iv:0uCKZP3jjDNfqUUeZddGAqg/2oCGsbID/Z1sNMUTytU=,tag:je9doKLshtf6b+YGHhAQ4w==,type:str]
+                description: ENC[AES256_GCM,data:7yl5PRGEi10n2ZxuiDObaPclZrBhXYvGvu8RDsB1gVI9K5RIg6ICvYaaWnXBlFudXa29rwGBdL0GzV2tC9r6EEl6yJfA2bkBV4tViXgVCN1DN+9gxBvKy+i8KkN7yNJEfcptgdazdPmtPZYvRmOCe05/O3i7BM1ZjM5ZTgTTPQUO+o+Cfg6iIhaecXmhkSMRYt8N5E7sthS4VCrdLCHOj2cAzITeU0m4zrlDwSxlJ6HDaikHKTRagYajeRsFGC9Qm10nNddHIp13/z4hzl5vLs0zZXmEqoSjhhBv3pwm/BgcK9CpOg0QHZib7sr6UZo8Uwqezok51nU74C3QjturcQ==,iv:MJh1+qAVJpN+wsOMnZn9lqMt2/a61LRhvb6sUfvELrw=,tag:ht29HWjhg/ovrkYcn0LXKg==,type:str]
+                status: ENC[AES256_GCM,data:gZAyz+ydN6xpM50=,iv:TOhLHs+O3Q4+zJ2ABMv4lO7XpByCHUYtI4LDuzuRtw0=,tag:t1MJNSRyfb3a9Jzu4RAYuA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:LL5Y8Bgb8hoatJT6,iv:njgejNWtm7JM9ThNydrziRuFKWlzvn3t+z0aj6Tn7B8=,tag:5lcSqkMOzmHPoZ8jva4PvA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:+Bh1uY8=,iv:u51srqQPMsE1gWhBt7Zzq7uNuCNIeREl8JnpKudePQ8=,tag:j93KOCbM2yuRhlrBdPN7Aw==,type:str]
+                description: ENC[AES256_GCM,data:xiaHTzW/hkqmnY5xORVI3Zl9HJZ0hXbcHWp/I1/qbTL63F0gx4pH6Xt4Gl7DXPdzceK7DbIaFJNjz604cuWnU/U0YIp4KbCmrYPDuz/LCLB3pSAo6GDXe10Uz5oBejFIht3phumqxJEVMEKgtYzcGXgBY+iLH/+JXYPF9e9b90smtA4qBFEAEX1CcZk9RZkMQvnvvwlHQnECArYEhAwmv/H1HbDCLlOMUIV2h6WznV/vok3yv7+w2Hw4ELePgc7K1X8K6+Eva/mm17mPl+uBxW2DcDEtiYJ/E27uGFh/RtYLVQxb4RUC7Xt/FLEuYT8rpup0975/t/X+hboiYJfbkwGpqij/Xi52KSjqBM54LA1XPMqOScb6LBbXW/zdPfAccQXKdjiloZyMkvvz/K33PYUjdw==,iv:RuJyCHlxnYMK3Ax51NqBatxujtrDDsefaiuQE5LyBEo=,tag:aKUFKttPLVXvC3xJH6f01Q==,type:str]
+                status: ENC[AES256_GCM,data:suxdY9OQ+IjtEUg=,iv:7CPA26Jf8eLEbbCxZ8rdBmzIaXHLyEMqVzQEawbrDz4=,tag:PjrvDNC+/4doNdncfvQFgQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:SlR6xH3iV+jKfPsfBnWXl5PWQIxn6Yp4EFTJKrA=,iv:4R15Gl8xR6rOdZwlFFmQOW5Fk35Vdu/s7yHi+91MuMk=,tag:yqVwZqZ4MGnxanqcFoTzvQ==,type:str]
+        description: ENC[AES256_GCM,data:yMFmRFJQFU8QzhlpLCP9g6mPCLTkWakX/fbPNb5Lpg0Zm8aNbFGWEVPQd3LfpRkp5kR0tTUObnbxwvwJxxHhifmqCQRQ5SVS398ckk1dwzQvwFw1uPD17Yay4xyWlLiCAK2bebUVMGHL4/21vVijr4aoNg==,iv:sczBPG0gSAhB6ymDXp46CfDy0G/u32VNgvHc2NdQWmk=,tag:vcf/oj65h+UjPTRG3bev1w==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:Uye/nLudiA==,iv:sKlMB/OwYUjqitSkWCfiD/O4BlN0V6ipX9qOzKEuXzM=,tag:PGMp0uibIZ3e0cuV6S/m/g==,type:int]
+            probability: ENC[AES256_GCM,data:O4wiuw==,iv:49o6Und5tvJJ3L9pTEjVTwa1VNq5EClsxwtZ/1kvOcA=,tag:zkm6D7aAOx85lOpKJ0zJrw==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:4s43tM+xLA==,iv:8sLJ/iY4POl9ApOeAFkbzGlE0ceI5waU+4tPXK7DQc8=,tag:0gDUg68AhZX4DvqTpe1chg==,type:int]
+            probability: ENC[AES256_GCM,data:JeZJ,iv:ML6FbXoXqzrd7xicPshC1zO33f31OFiBSuBWNLNig9o=,tag:W/c9tqQ6+SL5cYbObFi7RQ==,type:float]
+        threatActors:
+            - ENC[AES256_GCM,data:eygG9K2+K5Jo67MdRbOWggQ=,iv:iWVQhQmyPbcpLbgWG1EsSap2nmxnugOuVxSdMk6g5rY=,tag:ZTDS/yp6RPq5jYHJJ7/Z/A==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:U1pp3syHXj20eVnB7A==,iv:xRpdeg3hVgUjU4wHc/JnRl43hlrhbihPlBlbVPI9DU0=,tag:/OgamHTuD9rtOml7lzc4Mw==,type:str]
+      title: ENC[AES256_GCM,data:NQIeBCZvFuYlNzdCZ13qJnaVUyJURE9lLKuDmKkiGXQMeVVxbuLn6KYk49gVviJs,iv:e5K2YyD3+t3Thq6HlsDcwz3PbPXLfpZ8XsuTuK1QHpM=,tag:xBhb1tek6QYqUxjdv4JriA==,type:str]
+    - scenario:
+        ID: ENC[AES256_GCM,data:NWs80aQ=,iv:aKXl8iuqhyW2YtViRVB0SNBslUTfSP3jBnywvDyEd6Q=,tag:Vd5ZQpnij+cPtwzCrx5/ZQ==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:Nx3IuXY=,iv:VN+XdSjBLS6/90QDNdbAavTdVAahnxoYiEeokP4xIWU=,tag:tJnnnVqjIW0JCADEWnnkug==,type:str]
+                description: ENC[AES256_GCM,data:z5cFKw/Xham81dnxW1KhMp2Pawdcn1nQKZp27PWC4GLvznefcIFZ51OX4+yJsHG3vtzonXKG7FEvRpw9YuhQQR5E7uigIK5pVwFuCxHIE73Qs3Pw2Fn4/y0nAFRR1ga7ylIOLXvoKbTYBzJzk3ERo6lEIS9akaLOmleSfqsjocDUuSNeZm8DImpDIky5GPnggmlah6iwaau6t8gRXzSVHrEf1hWd0yH8wU5mXUrruSPhqKTRvzyhtFvQ08eafDr7uv1fCJUbZKSE7txRsSwrlDtDs3wNLQMk,iv:fn58Vn7jYySWe4ItDX5Pc7COI0TdRNd0y2UFYxa4Yg4=,tag:dIE7REzRBVdN3IJ/jTX0Jg==,type:str]
+                status: ENC[AES256_GCM,data:3PNBAsLmCQvSXZY=,iv:c3DX9rNKonUcocX6EnAz67NwXyL9hDyG5ufW/zfXv30=,tag:D8uyo0wNuH9+aJm+i7eNOg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:S372AImb+us48tI=,iv:83kC1xsqRTcW93mGBv/GzbpA9kMz152Plzacwi1qS1U=,tag:VbLHmzHRf6kQxaYoW6SCvw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:Z6aAJoY=,iv:JHbp9R+cF/vy2TzjF9ZRlgo1cElOZ2kr4fw5tyT/YMM=,tag:WBzR/MfuCaQYEpobQuDQFw==,type:str]
+                description: ENC[AES256_GCM,data:RV/6qWgkZ6Jc3lhtgYG8nzeED5K+IITxcOP0Q3aQFy+OfuF4lrZTxmsZcUeSefTZTzIK2+zYkAYJUhqUmSe4Cy+77tjx9lzrOfz1D+DSN7r39zgIJhvM15cv1lrDqX6CQ/rHrIUo238OxRtPXeVnjK14R8/ZadtCWH+9gXJmCi/XPj7Cuxevjmvs8ypgAtffqCMo2UxJ8OcIiJeFT1TsQgbxfiCjbkwBH+CD3dkWp1r+jMwSaAFZDme1g+1RUelDxISm5TV3Br5vXpom4ny0jORUsEcWXYebdq6+bUCkvo0NOhAXu41KEkBKhkXRfcZU/YMVuHKERqp/R03jCcbm9cRYoM52wrYj95ExNWHE3froQaarrHW813NH9ft4RhQRkg==,iv:RlZ11OE+UkYIGTCvm/LCZzEYllaZ4hHg6HFzBOgpVVc=,tag:aVWgW8pmjI80+HhqLd0rVw==,type:str]
+                status: ENC[AES256_GCM,data:mf8qb2CGE8xHGh4=,iv:x6Q9i8bB/JS+VTOip6VpWPzqDJYUJkwo7pK2yre8ZFE=,tag:QHCdnjJnFAVv0jlPmpZF9A==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:VXP9vDp5myjH7RGdSQFj3Uyr2p5ALrmrADQ=,iv:1ruLbRrnA6Nk5cuKwGOLryoiqRFQvYEpB/NW8Z6X4ZI=,tag:p98a6EJaR1LSzwNqfLKgpA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:6DnJJ/c=,iv:oBpSvtf6c8ZiQT4v0YhFNyDlWvtBpmcMSV9643QiuYA=,tag:S/PPsLK7WCrWw03lLRKKQg==,type:str]
+                description: ENC[AES256_GCM,data:56+6v2uzpbF8PIakxG4OkemvBFgYXp9CzI8f2XG0o7vxh5+iivdD2Mf6aLESKPMLMgbrQbIsHNwOuaIQVaFwxZ6bqTnORygXdllBKWNkLK2L2RQc40ldhP6cZk68gxPi6318xaJpch0GIulgV6DXIwNsxjliR7PwHMAWsvqBLCgLsY4CNqJsVFQyTfvmbPAYbdSdY5ETX3CWb1E9cdOqJpuMomyfMb7GNLh1stq0k173nQ6Pw8/tQiz2YfTLvmq+w7ffWxex3zRMsy9nPWGGkq2hVtyjCqyn0/JLgzTddcUL99hjU/es5qCN2N5Xia34BMZVJMsqRUHd5Q5TJ7h7xcOjO/VdBdFx2g==,iv:H/pWvzIboKGR5vIX7Z+FQWezuRugAWd9U7XR9GQZv10=,tag:2m4jIzLd/I+GpCcj3sS4sQ==,type:str]
+                status: ENC[AES256_GCM,data:X4YkmYJnEqcU6Qc=,iv:Yc/ZViPfnwTlZfoY/3l9NsCGl/rsuJD/DVsoCuW3Q0o=,tag:N1dLtmY10ZjDht3CXp5dmA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:KVjgjTnQrQg06ThWI0uZwWnBDFw1Hh/1fBor,iv:k5/9BWnc2HEnWkhI+5jFa97wVrMNqB0ptMxKnBnzYSI=,tag:eWt4q0NwpUS72WBcasnFng==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:K3o7aFQ=,iv:8LY3qTkRzjPKpwgqGB0yXnYSEBrxD9Cu+Rxn42JKI+E=,tag:YCv5JVhrLgiURFicu9sq4g==,type:str]
+                description: ENC[AES256_GCM,data:QVImX915mCRTCyII1/DW3djV8hGH6mYBw8BQoD6j5330tXuIkyV7c7qTK2ROSG0GmK+wfIj3RwYMa31Pf57r2scAMoRpMQhdNbe7qx0aXoM+8cyrvoNe3Qiv5HP0CZC3KKqd8FeuKd+yQ1Pk99lo37Vx91EfABKghevM2h5807y7uzE0AyPMsRf6ObdIUMXj5TYYXq6zlNca5aX81dTsTpPBHmqCaJRDwrl+AjBjSYUdq3p7KvSZwusbug+44y3B476HynqHsRGnzAd2IwIK,iv:8XyJ6XgbO13DyyHZlKVcwvJr39RaJ8lm+3G9fkeObyU=,tag:vSCxROwiXLx21TDUqUdlKA==,type:str]
+                status: ENC[AES256_GCM,data:xYF3L0N7XBsFPUE=,iv:5nr27sH3K7LFC6O5FzXoXaAkBOnHzmHNCGDlYiY8x4A=,tag:RMK7rV3NUENUY2pWZN29Hg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:6pFuAUpanSQKmGw4kk3yNv4dJbYvUYY=,iv:Gwq+R7HSFM/LKqxMS3kLL1TxfMCAWWL5EZVDWH1gRHw=,tag:MIi1s5MrqeTTwihSmFQbjg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:ugiqR6s=,iv:WNlZ3JZG4OIkHGDJaj8iHpQVvuZ0PTj8ApVqSGb/ggQ=,tag:B1DiFRc6bATRt1XNf1Uuuw==,type:str]
+                description: ENC[AES256_GCM,data:7m91MEh8eeuoOSHEYp6eUCm/ZSRMuoYhZFwhNY6Nw2B+ar1DeYNCezgxpcaFLX7EXb98HKgDdpUm+ntqBpi1+hLtFsm5xdPYvt0v+kbvpH1cUdXweyxvQo8uR9LzZ/i6kaVmpV94HIekstO5z7+NgZURnjog5BKAeeRckHdJXqzzMgFdl2iv6ktXo3XetZ2B9dnbUkRQlnsRxw6bwS0yOHO+ISJVgQB521ocmegXRYh6WPToC37QPws=,iv:/9ICIzoC7tMNUTmYMl9BS7G2sGLcMq4nkZT593jTLSM=,tag:oKJSfzIAnNHSKMsjEZ3f3Q==,type:str]
+                status: ENC[AES256_GCM,data:UPgOWLh4p+kxLNI=,iv:HcLhzyLRYkh68FkdLCZH8TDjqP1z4stzS5M/T04watQ=,tag:5MGx7Y2Lo8SFaBy81mc4YA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:YqC1ufklKsc/dYqw1e5V5q2Ch4IKfb5GkSo0Mg==,iv:G6SbHDMmDM7mseIrvir7dgCA9A2vpc2HSPquE+LI/V8=,tag:G5f0vm9fz0gv1FqoJh/xfw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:Z9X++Ys=,iv:zMt7rTpvS5NDPAmfc3wFTXTr3ehGx47fSnG/ErJqvWM=,tag:qTvmSL5PqNX8QruHvbx+aA==,type:str]
+                description: ENC[AES256_GCM,data:ADaXSRRxHbDJZTXYaa5Z60Wd+CAzwlTZS7XaooYqOtmd8uHJE1G7kWtnx3ntAKl0W5idieGTmqvn1V5P+97jAGKlibVf5Fked3LePoV460kSltnu00YZeIwGb+TpOYC5oOo7Ofcxq4ZlCqwfIigAD2D2UDwXDTFzltdLKAmHQO6s+iVb16LNoAzlXL+/te7elaKoupj/+Tq1oQq6ng+YCUfU2S5qKuSuarTAu4Vco/p5noPn1fj+XlLOfUTrQjZHzZL/vfklA/m/Ms66isCwcgTQTtQVKeRHxI8YD7V0e3idZYTH8J9b/Yk19LdPG74ZUyom8ci2zwOQCVBzTIeTt4IkCsAagOa9oIZmr2SW4Kx5Tq2FHW9+/WJvd4VaF9LcGSbgCbc+BAelTLpqCRX4eOhT99qi4MSb488SVKotl5fsomIYlGzFMIj0dW3ykcKejKWCJu7n8EBkmbwXrYAWL2Pv7ySZUu2TI/aNs5QJsuQF62Fkn08fq9x6IHZRD4tolgqDD2icT5eZcFJbLlbN342Ylu40UvA05q+ze3HKVm/r2nPnWmHGLFRqPxBSikvCwIYtqiYStAOZb8faoXYoqzFKAKXrNcOQOXQ6IefBSxLW0YOxHeZ7EY2m+c1c8eTUOZ+VZSxd68mucFGw5JXTAWpvQKdGvwqTWt60cMFS6flfahZEMw2fZ6BRsNUz0uSFaCaPCzYNSMFN9U7+yHVsObVLaDrxPPcKA3RISd3pMoUTVo32yWA9HYYwZrkknwAMQA+nseH2XXp91rzcLij+UMMY91l8tq1rY+Kt1wT9gzHy5kKsL70SklClTFVP8cNsM5JSiHLlLvIQyFnWnYNkWEuPZai8fW7Gx2iiXD9U0KIC2Vh2VeJv3Oq5uwyRikTCB9Z1rghvi5/F3eq8yDDFtPH6tG6V3YukO6M8mkvmZzYg34OEWAC2DZ1fiZfLZJ6vM9IA6RJDJNbbFPt0rKtjAZbAoGKVFRzkv4MBo2b05UKvbqlwSdnlD9s=,iv:IOggmA40Usbt+wrt0MevY1MYi50mvqVS3SPEhBm1m10=,tag:eVNcdhzcTIwQQAQ2YYK74Q==,type:str]
+                status: ENC[AES256_GCM,data:fiaQL619CM/Xb6I=,iv:bnhikvoSilHsDLmVLo1RHeKhHUgr1sqGnboCjb9AnyY=,tag:L+4h13GL2Hhd0vnbDbdkbg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:mzlJloyg7Jszfr7zDP3tHlqAO5kR/ZuSMmBL,iv:YBTxx5YcL2UlKwxgA4pPCoOvmgY0BrmctPz6g3pERDE=,tag:VhU1vcy5T7iIlnPrGgKK4g==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:XpeBci8=,iv:wbA8iix9gBOy+fGUHTMJevo1tTkGxQghwKW5tedUdQg=,tag:BxuHa7nDtVNvvlL4AclODw==,type:str]
+                description: ENC[AES256_GCM,data:3yZCvUMVY5nrx4OWC8V0mRf3L4gJF5nDrESM4GXVaQ97HvDFt0OXBwa25efxLUJmqfPWRM6PSu6kwZiIvVDLf51J1XAzlpGKyl3y9pHPc6xvGFXaYgQXjsQIXoJLvLaLZTpW0rGOgnpxdtRbkcx7gRILRCgnF/1dxejOEwPrOZ1q49iYE1YJrXjlkPpaZ1JEKKBVNi0/vL+CcVZn9RfY91wpmllky7Iw1lB209pqC/f/FGQ6I6BUlRiCCTW5r+IJwcABZZx7dCiATDBfVoMrvvsrPGuQlgoLffmQhE4kErr6x8M59eFFFtcelA==,iv:M61WGRI/90hiz11DX/QXJHidEVmkFAVneXclWOY7BeE=,tag:Z+/eqAw+vi0HXzy+/NCU8A==,type:str]
+                status: ENC[AES256_GCM,data:/X2yCSNVZiW9JmU=,iv:nIu3FTVL68atfB3KPmD4fc2IPGtPlZepyl2fKVilAnY=,tag:qDrVvs0V0GmshP4VSTVfFw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:yToqZdpENWmZByi3omBVaYY54OQVgg==,iv:aH0HxkYCzeYujMCOy7o8HfOwrA2+OT1y0w4Ou+9BVsc=,tag:ObpZQFZodeuR6lV7JrXJkg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:6cOL3Xw=,iv:1HWZt6E6lELim4kUBbws5dqy0bhU+pKeCHtE4wAsGwY=,tag:E5JFpngfEtqf6R9pK5SXiA==,type:str]
+                description: ENC[AES256_GCM,data:iCTOOIbAL4wjZ22mRKyyDPbbUimUbi/aZgMWBT0OBwYkEMjPU9E5EIdJQtrN1ugEzaEqOdqRkISAV1Q4AFGzTdBFsZ9kTj8Q7zdBlhZGjwi3UJqaySikEc7k3d+Oztoc+Lz0EMUAx6EPxvohTTpoayibR2zVJjU+jOWSG+a+Omf0yiKDWmlZ6QvzhfeOzyh2L2IqAEIbok3KSoRtneVCf7eExBrnxUchBRDCehvZlPdt6Eq9apsBQp4N9B3ziRreZbhfVgE5K0oyhBktKzIXNjOiiEWPJBDuY4NNuMnSATCmBl98ktaUQ+touIE6MKtbQ6nod/vHtIY+YtxgRJdRmvDqLwmtk0KkFT2P+Woz/DL9gv7bizZDVgdroErXXtaKaS+AElwAosBRg/rI4Yyw3qQC6dNdC6fztscLB6h/CyaE7SYl81dX71aRIpn1sJ0CiFlUO5UGA3+IWu15Yr3S,iv:Rfh3BSANxmLJHybkA8a9YBHqE9b3DDYO8JYCoLspUyU=,tag:WNELuirSn7PuTaOmHKzvaA==,type:str]
+                status: ENC[AES256_GCM,data:vpzf9rG1I/SmSqw=,iv:Na+OFmXlqHtLF4BLB306ttaEsdV9NmT1eSq6k5+X3hU=,tag:/N1BdPvVx/hW7i5ol9gOew==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:Vn59UQ53Q1wCcD1YRPXxZxQbInzOXA==,iv:leYaizKvDZ5lK9Veap20EHtSjctqn172ZeodtAYO7kI=,tag:jwwXG0r1uW8JktWLHxJT/A==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:L4L8838=,iv:sQYK4F+4MF39bDP/6n0n8mZzj4p0tAjZ17CRXXBGaBA=,tag:6A6cQPsVUUlXV/2RjslA1A==,type:str]
+                description: ENC[AES256_GCM,data:4L8e8IzM/xdZwSKQS58OCwTSEIMkw+AXNlQtor8SGzsMZAjP/kV2vB3WuebUaPnxN/PNVAgPa7UXtoO8gm3a2irXH47Bj1HSn9H+GzTumioiihJjDOHoawa6DhULx8UzVIvRkClG1D3tyK2022uZ2c/3ToPCN2KpSCGkpfMdnJPeMPCUCtymiceTH3pUWbfVwHG1bWnuxQgBVaWctyaLHL9eO2G+Fq1G+/bHeoooJz6m8kIbalwp1c8V8ymMMt2AqLjVbBy/0I/fvDBN9QCJTZJo10RK3BaExHK2MeMf7jBDco0LemsJdjljgebNTDh4lWt3i3nskuGS60tfhb3nYL/Nmh9wgX/euK0FHAKGgup/5RhvG0ZAEJLxbOND+y9Nt6NqHC39zyldwRwqrkVA8TJ8kPyMmheODq9GeY/2+1xOdBzWLcMuxVT9fr087LVl+/Y=,iv:0GWJ1ynrq+VdnzujKzVr9yBxPSRsz98Rfps25LNRiCc=,tag:gySVK5NPlPWFnV5/M+GEJQ==,type:str]
+                status: ENC[AES256_GCM,data:/53ko41cDJ+nNHI=,iv:0KMm14BypvBwJ68T2biiZFCcb1vCWhkUOOk5UVbMFdQ=,tag:5OQ1FgJSFi1rNuGXE5yVPQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:pFMgxoyeuvyXOTHk2ECLDfs=,iv:so9YaB+BDdbQUBNiUAxHas3VOYNDt7k31TsSjDoHxAU=,tag:H43VI32tIpwSXJt/2GeMMw==,type:str]
+        description: ENC[AES256_GCM,data:f57SmUyvUzc1qQWrzm+62gxf7FLneIhRHgVEBt59pXch51QHYn/zS1wQ5ZinG88Fh3cuEpFJitj1iLg0vouJx6EmwtzEJkUrqQX0gvscLvZvbSC2vbQ8thKG5SXoJHOCc5L3aHPEuPvfDy1Ll4mobd/Om/zeN22ctOD1KnVFQFOAE0AHNpWr7w6USf6TKOIwiVJhPBg3jw+b/vXHU9UPR8ctoe59E0KuqVxqcIWBBgvU+Cjn2DL+/8C+HzJuH2j2lNIkI3SuDqs5GVpzwtGIDSEr8aMJWmSyYHRA1gIXSQnsL4teh4k4TVkBbatyb+x8Sh4xlkmqE1eMrFVX8oGqnVCd,iv:xfT4VICpB4Kr42yx08cTn5hFbAoVQFZKtkThxpZ+6M4=,tag:15aQ4Ln+F5Ec5fOIAkAAng==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:3E9m/+8=,iv:23m0b4MDfWORU0Cf+kKXI0T89hnBpg0WAc5klVzwYRw=,tag:0Rhr0qhpkt9MkC4qq9q/ow==,type:int]
+            probability: ENC[AES256_GCM,data:jHaJ+w==,iv:19N/VSQXVKl5hFUykdV38A48cEUA7NAz7CX31QJgHos=,tag:EhcITCCMnktNUBQeIfobDQ==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:8O2FFrA=,iv:2ndoCD9uhTlIvkvs4tL9nHNbI7TbHzvcI9mxU2/TS8U=,tag:RprTw07YXtWKNrWant5eSw==,type:int]
+            probability: ENC[AES256_GCM,data:KMI=,iv:gAo1ndg0Jm6wObTXxcKsUZ/kRBcgecq9N/YzPCzYexc=,tag:X/7AHlFkJr65h1QIthG/Eg==,type:int]
+        threatActors:
+            - ENC[AES256_GCM,data:IlHop74VrQkQDQ==,iv:U1cXrzZ6w0QexTTNlHQKUAKLBtYixRRD14aapi0H6Dg=,tag:M239KsLSM5MJYupXlfwGmA==,type:str]
+            - ENC[AES256_GCM,data:hH2YmmrBtjGw0ypRMw==,iv:oXwo8Jtoy3Ocqr6FFtFDlo0lorqNSpKFeLkUizcRLdw=,tag:CPhZdYHfItmgtTVaopfaxw==,type:str]
+            - ENC[AES256_GCM,data:Fbn+yYpPDSO3vGbHx000OAyZgykAvA==,iv:hr+1RxT1OiXD5sWonEx9veQxOlbS+O8Vcb089blbOWs=,tag:fdeh+jl9Pni6cgqlHtCE7Q==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:+jeJvVQm9tAF24ClWw==,iv:08gAFt6pIoVpEA1mqxR470EA3budZbBrC+FwRSlvTrQ=,tag:wPAH9eHL9Bj7wjJxSAx7vw==,type:str]
+      title: ENC[AES256_GCM,data:GKEblFWmecgBMRs8H0C1oF1CfeuIser5gYyti3bLFUAu5h7QYldAhcJu8/vDx6Dp,iv:OwcW+bXPad9QcLa1fzefdH2c6DSDHPJH2IWX16z6aXs=,tag:Gn1T6h1500Z4UoycgH2Phg==,type:str]
+    - scenario:
+        ID: ENC[AES256_GCM,data:lRI2VBY=,iv:246pXtaAAswbIDzEBPTOywm5n9hMVqEeVjEOH6bhJQk=,tag:QdKkyX2gAvoLNAkwYpcZOQ==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:umf0/Bs=,iv:fXVnX4gb2bSYpyyjYNNzauP8I+zXZIqdGVo1EZJQ6PM=,tag:+ms3IZ34TyLEcieFM12NUw==,type:str]
+                description: ENC[AES256_GCM,data:gOlRGLTatQWs6J0Bl++W4ChOmUTD3gGJDrNnVekaBS2GQXXOBCzKSC1h2pQVanzQZlRk8MeCFVWepQE3y0yKjKnwgnG0sCJkz4zS697EPNQBlP5MSuaDySxnwyzG99x895G0wvLFvbft3/gm7Jt3uDrwQ5c+mmLrOXzTqkOW5wLuKcDCnyXDdbWlkhCwPLiZkEhjFCIyGzReij8BJ2EkwqHziNah1YoXPGBfV8/k7v2Dobf+qh8XM7dTrWv8nCIKHM0KzaUyjuQ=,iv:J4Vg9hytiTs2uFDeSOmJMVtRWflTgAH8ZH+ESICNSss=,tag:zvkbY0JZhJfsUCr8m3wApw==,type:str]
+                status: ENC[AES256_GCM,data:J/qCmJ01ICXkrRg=,iv:0w6SmdWW6h5v4VGJpdbrKmXzhGyda4Bw8MsgQX2sIWc=,tag:vnqG+2oOpdUc9pyclclhYw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:cQuKpPzDeMfHjO22BuOZ8cmAK5hM,iv:1UW6Iv1jPGC2xxgchaS3vBiNPvVkUS5DC58Rb06+ViY=,tag:cKJA5n3Ivytb5rdCuIIHZw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:w+CLxrY=,iv:N45LgU40wkqQu4vC0LBG+ftjNMWR599L/nFVO28w1Zk=,tag:5r4I4KYcT1JGDK39vVumig==,type:str]
+                description: ENC[AES256_GCM,data:g4N7KFS3s82evweb2WrxJRNzG6SBtQAlGtpqYjvulREBxyUuDNK/lmt7AmUk8oPEgd5HOlv6yADEW40r8h0+9mmesNBMHNIKV5xpKuDovc891HjEHwGWFrymS2X65mAWNVzCvsbCkXbJleDye2Ld4mId+gJhfJi7+7iSgn0Q/U+jF2hHXhz5Rth7mgkpL+4ddvTeqKIxDc5trVfPP4I0TZMG4M6TmKdLSsvhD6jHpbW1+SNyJj+L+d+ggLTj6TADyuFDdCKcP5AHXZlgATHpNg==,iv:6ZT7FZlmu1i0i28246ac4+q9KqsEqQSxAfNGH0hmMvA=,tag:tSf/HYkieppfBwkygUMEwA==,type:str]
+                status: ENC[AES256_GCM,data:5ffrrzRryj9ifTw=,iv:m/PFujzfsABRFrsCxvwrOsVjaQDz5fosxpGHnMOXNsw=,tag:SmwEF3vENycEF+0/Mo5mXA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:aQuIcKkyOrcZvbPsUV8wufn8dwc62H0=,iv:HG6xNMVgJ2gB4kJdnbK192LVQb7X3quX+tQty5MUSsE=,tag:vzpQZRxQFTG/UY0q41vDQg==,type:str]
+        description: ENC[AES256_GCM,data:kSdgFxt2gxwxwZDDpCApa3puBrboEVVyskjUO2AwyQ1fonEF4YI7DhP41szkmdEBmJNIm0l/M6Xv7kdcrHUhsJDCXHteGDEoJgaTbBCiyGNocT6ifghW3VxiyVBCQGhLIsTD1Dw0kEBzGsKyvEq/0bPzhx8c/TBv4VMmw9pwv9IRPmzDFgXm7TwB2jn2zrisRHhlKHv9i2a9iyrx1lb9y4xImaD0q5NJ9nH/mNCzcRdrDBkKI1Yv1v6f1jyIil4=,iv:8+bGota8QFi7fYAh0dSBgauf0VDA9fp5p/Cm6r7a1XM=,tag:dL4FVqHTdlv4oCTRBzxlCA==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:7kqQXJU=,iv:TBcxAtbZLq3qPmf7buNuJHHssHfXLKmpY39g4cUvJtg=,tag:hd5uUus+nAfs7ASFoax5lA==,type:int]
+            probability: ENC[AES256_GCM,data:bxaXlw==,iv:vqdacoBFp+h7FXC4wMY9bCs11hDKxPgZ1c+mgTx4nNM=,tag:HI54p/2Dm5NlT59o9BS/Rg==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:TxR1V7Q=,iv:7ZnLWyWEgBcJqmR/+XYHGMInYgDN6jfETVixPZfGIQ8=,tag:KTw4SEJ5s9HhLvxjDJjl/Q==,type:int]
+            probability: ENC[AES256_GCM,data:aUk=,iv:mHbPh/yaiDtmnbIUNRIAmHwd5r/yY2nMWfdywaHoxRE=,tag:tZYohwTJfKCj1y73RHN6ww==,type:int]
+        threatActors:
+            - ENC[AES256_GCM,data:pG+5A7C9eue81pmAJGWf,iv:E8OFi9FRKl+k3xyxSliKW8XBhsaNg2NK9NyIjavKIDM=,tag:6exwZez00YBIGhHispA7+A==,type:str]
+            - ENC[AES256_GCM,data:+6Kxna0gCkuf5O1AgpzsBBGbjPiJug==,iv:Pw76PJ16DOIuCBByVUr+nmYlr4NezBtx/PiFO+yi5eM=,tag:WvHQ8W866DvBXIQjajvXrw==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:pPnsynJgj0cg4SpU3w==,iv:yHJ0IheFOkne70wtRHSxv+DPwqXxozE2dVtrkKijMHA=,tag:sS2XI7fyzpjTbWvN+BMXmw==,type:str]
+            - ENC[AES256_GCM,data:tS4kxwVEIj35iLo979BK,iv:n/H0H4195Ozb+6ZBVVwJzET+90iw5T35hKh/+ORDPXY=,tag:04Lbk9EdtLdfhm+JkZlmCA==,type:str]
+      title: ENC[AES256_GCM,data:Zxw/WWadx8AR1/XYe2x5tCO2U8gWOY3TkSF0Iwb/6LrK6thb0CbZotjYEZ/WzLdn,iv:0PX8ueoUSsB1FMmH4SE48gnGYRICbSxXoVCKGhAsfHs=,tag:q/7a5ek9CQnw+l/8StGE5A==,type:str]
+    - scenario:
+        ID: ENC[AES256_GCM,data:PY5WXro=,iv:qGMGjHCCR1tKby0ArR2xQqlNSuVd+sysbztOxxdXzcs=,tag:n3r1JWcrfZLKLh/hzWF24A==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:zjwDljk=,iv:ARvzZIGzFSMo/DukZowg+yrfSwk+Twl55clj8LmZ66w=,tag:lNrecScdzjrUHJXPzicfBg==,type:str]
+                description: ENC[AES256_GCM,data:jlEXTKg8jp9V9SpkwMAOJ9xVxFi58erjRX1UIgRYVAkKvTkPcLV3b1AiZC9CURFhHLPfJoIMgPgsUH9TNsuRayxh9cvMiB/zHayMvN7l3Q9KGk0YXEwtZu49dxZpUO7KE4JA0dJmH7bPjta1SuGyaXFYSmkkDwphv5Htvjcm998Le6DjB3MKl4Kw3AE6Pj9ZJzHWn0ddTau/Ouj5u7HiGBXTEUUKXSgNKLz03imPtYnpQR1kDWhAJSYQNM083tT0sxQpF6lZ8NmrGuJesG78aVKzkwWzHjaLH7s5pjGoOg==,iv:9CSgoTFXVws75NIsOCXguCXAtPh7jl7O1VbS4x6N1Dc=,tag:nJPbY0K/pPpitKk3cvO20Q==,type:str]
+                status: ENC[AES256_GCM,data:nilAg/CPcDjAqcY=,iv:Krf4CKlDa2M36yJk7ad9AzAEkctbXoWNNDdo8RQ+Bx0=,tag:w4M5a11x4O9WLBPOyy9jtQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:7zWvpUfD1OF8xHj7+Mlr9/KeGtgTo8SkKRw=,iv:Tw0Y0tlJWV9fwpCSzk//ySHG1E4wV4GGQzrWT6ERjdk=,tag:Ci3n2EBrBswEeUrIODK4gQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:OzoMlyM=,iv:O0bavZc5izV3yh+i+myZmr3bhaxUEQw9byhXsS2Ujwo=,tag:Ljq9S6+N16ci5Nr9Zvm6hA==,type:str]
+                description: ENC[AES256_GCM,data:82hbjyK2zLWAh3tOqrM2VreZMZfiG14g2KozqIHCmQYiTYhJdoyrJ7HP5Uzw4VPzemoNsIcTyof1K2H8ARolCAFeSRqlh1SPDhQgUoY+gyPG1qOXXPYonwIiQ6Grvo/BvxsgkfGM9M/neBuuBlBBMGZ3++tjLD3ui55Wr4IRv0X5DMBI1xwdPgvgXg3c8CRNWpUsf/DG3xMrIZp8BCqhRboplI8JNDGy3IqrEypgui5iIY8XEkM/5pdCOgJu2xxuvqKI6pizCuPBU7U4HpgPxOkIlxGayDZ8mQZawx7h6urHP6TgqVOGd0MHynAd2UB/RKv+HTv4TMFBKdj8uLsMnB5l11+99l968lQZCYdjocAdrLqOJV+TTrzWq4Cw2kBBXbXA0NZsJfCrpvbk3Txdc7itjzOpvP7/cSPhY0cbqJKia4vLLoZwOVBiE11ULaEkMF/CTLWIUWzWkGjhI2QTwEVCza7LXlERXUJCIGpt7Uq9lA==,iv:AIf8HG6YgO1pPUX76s2wGdR4DIWkSm9xa4iIm1BGo4g=,tag:KRaV5iSZ6UoS4oXNEbvURg==,type:str]
+                status: ENC[AES256_GCM,data:FPSb1U3bj3a0DNc=,iv:co9amekgBRku5qhMdR8T7Kr+JR7abnDBP9aDWUeDYxg=,tag:6nzfIJFg+XeqhY1Mct7qiA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:VLzcnEJwU9+1jhMI+oeKbFhYJIjedX0hq40=,iv:+U+Sr9X3ClBXEQHv8hSjrQB5wdQ+lCSyaBjyVv5Wm9Y=,tag:MSxw6Q+3RN/3v6+2TuWuhw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:lxgnQn4=,iv:/cN9ohlnsjWcscRZFZ4RYpAsxlkF3OCzu3kL+fqKrUo=,tag:4cGF+xBQLqTH7nyssCAU8w==,type:str]
+                description: ENC[AES256_GCM,data:9Y1P3Uh7cqljp5fofBlZNFMQNa8X7X+0z7EKu+SgfcWasH3JMgH5VYrmgzH9S5TL3UR1O+zxdNI/+b/HZS2PznRs/gb4zxXhrgIlu5MoE9bUYSv4fBNPepB65PFLRD3Hp6MLUXlske9qcZagfTGhsvAF/wD3JMioYVrWBGm5rT8IrkiV8uiYWD+4tCKE985NG+XpKq5kA3O63j2iOybFX4eHXnfYt/c04p+wrJnT9Kpw7fsTGw6442yRCtrgJXbWukmp/iLpMTkiNs+TYLcolqUnRfP26o9be+fP0rtfuncYyMYRs5jon6HoAJ6XA9Vl7qncb7QCT1k1iLFZwikqAJPhTd0boDmWLAOwzKsygIC1jjE3eDngm1+GOgahj9uKio+Gy69OgGm+KlOJpKmqZ0GWf0DfYzo5rcFI/BEBQ7rDn0VbZyz8Hz0XIXsEDmGA6A8vJclBFlyLM+4b35W8RfRn7M6pQX0j+Q91D8BqK3j4oGEdlp701mQB/bku1nEqIyISqnxBP6ymi3bnmPu4L1NMqVVmfEqT6kT1siu+fZGIhxoka5LzyxUVVaHJpQ5+iAm5VQSTlGs0Q8x900cdNa5wiMiEsB0R3bLtb9GqlhlCqF35BisvAn8nX/CyKfV/AhXHPr8=,iv:EAWC7vS3rsE9LGFIrSOjYznJ7/3+GXQZQPDhGVcukYk=,tag:KsOcE8UXK1gGq8mq1lVdBA==,type:str]
+                status: ENC[AES256_GCM,data:zk13XuJVDNFC0xc=,iv:nzIMOrxJfPCK2C5uBXAmvy5gqnXyIEUZu+QK1mK5O1s=,tag:tH6dW9YKWJ+DUJuq5qkSbQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:0gXnb4DDqWzTtfyu5yzAPOb1tA==,iv:2J1XVJl5KFGOPz9o7h/lrBk0dDkZoD9RuT3zVRnzuL4=,tag:kUbaH5DixqAnV2X8xkDbgw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:fMKdJEo=,iv:poA1VTAcE8xiFEhPT/6jhzXFhfh8FKbO/RmqtikXIXE=,tag:69ZdG8c/TIAoew28Nc6/Qw==,type:str]
+                description: ENC[AES256_GCM,data:jVuqCvLj6HrFy7wT7JGSYR6MaebtML+nt4yyFKWNnLUlizx+giutQhAq4nmLqBCN4M8OYqRLrEn1f5SyUu62kT/2azlGO24GWPSyBjXqxvovsoV4BTQXGkTss14NNHQ9Izubro4Bz4yg+pF+cOzs5qrVuFOO6DH/uXEa7OuWUsGbYvvDDlrIT9w8g4sUghSU1fgAJA+1wQ+DB3H0PtVontIlfsCRnezNJRxESZkXueSv6/DTWpB0e3LgkSgdjtovJxW0hb93zupN1IPw/uJGCA/MbyJ8L3Yw79yVtM0SDS2MmRHYEGY32Zp91eJiBQKNAFd5jOCEuNFpvypRApT7SXpsigGygEaU+5JOTvCmiv31uVeFq3UiLK/JGLX032D5K8Nm1mBP7gEa8+mflWsnif8zwA1u2R6/kpXeNpv1yrSe58eA0owCbZtEA2uLeI8jmbwf,iv:aE5GiLVMOU5Rix4ZAwx4VKKMVZKoxmjnXjKzURV601U=,tag:cbIQSN9ucwqFU2IMjYtx/A==,type:str]
+                status: ENC[AES256_GCM,data:V12vE9LBOUXss9g=,iv:KW0URT1zVaKRr+oZOHeXcVtndg2KqEkw9Vr3PTqo+/I=,tag:fxc7niRi5+5voh2YRXJAaw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:ZAASyibTDBVW0B5YG1l/dyK+yI0wd7r+,iv:nqql1mfkXoeIw0GInRr8/EJm+xA3n+XLMtzMCayrGY0=,tag:au+Lqj9uM7CuZxSkbDcC1A==,type:str]
+        description: ENC[AES256_GCM,data:gT0xgf1aXIudOBblU2kvXpIsAKaFjOvWbFjE3XqsEzGZd6iJoyHj3u54tWhlUfIrjsjZ++aiGM32k1nkVSoGgtJJo7JY8eoi2PcuGgHNYhOFLUBGMzDHScWfZUP+DH4c6vidA5jSda30SrDxaBS07qk26orRgOEfrzERkrQcm0Nj5FWsY0eLPVX8V2im7zlUv2Ja9+1OL4PWeNGH5XZy+zpCoN2caKXwkLTo2isIUjKsjGA8f+nB16i6dN5WUwMRqul4IYF3qiy3iva9yGORv/KMJCScJ87svjfPG/4OrHcGl3FFPkSybv4WHF5qWSf1YCtwQGg=,iv:1zGwCU6yPKjiZM7az2qHg2WvUjcBZkwAH2K5Ze/TZ4c=,tag:TvH+/Zp0H92+dY65my7dgQ==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:GRgM0yzRLA==,iv:KOdtAG82rK5UWiO68O3EWtwCe2VEZD3F66tP7n+dFPE=,tag:ulYZazAuT7woYLc5FIFv2Q==,type:int]
+            probability: ENC[AES256_GCM,data:LtKtuQ==,iv:UuXYFiFP7YJ+t8fioPF3H6DxiRo/wFy3ll6HxuIKKK8=,tag:4BC6az/Ej5VJ5iNucbojAA==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:3tveM5hczTI=,iv:Dnkdy9MTootpEKdUtPgXsF0a+DKAizD2vwPEI4+lHWA=,tag:uYiv06qwvuTjDk+5XuNJUQ==,type:int]
+            probability: ENC[AES256_GCM,data:KQ==,iv:3b0HZPEyxv60YzJgiMRTPHJ0nKnGIP7LlcmMfRhgjk4=,tag:UOJkxWNjaPhRTKGVPOhB1g==,type:int]
+        threatActors:
+            - ENC[AES256_GCM,data:EB91c3FK+Q==,iv:PC87m1TZOGFnQXwzAG4orqS1mKS8THiS8STzFLeKmb0=,tag:cOMNCsWltE7FSoKUcQJE6A==,type:str]
+            - ENC[AES256_GCM,data:Sk6yHP7XUm0eINJxKGlwu8I=,iv:TrQqUTqMf1MPFOQVdX+PN7n9t9RGkvAQO6CV7rW1GV8=,tag:sGipEchQ4GT45RIX1bcTTg==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:KEaLqOssQwZ8TWp3v2t8mcQnHg==,iv:F3gPI/StgtQHHFFEloqEtWQ0Rt1oJb+yV2WvSlFFirM=,tag:nZEZUSPPBqH5bKKooHGjng==,type:str]
+      title: ENC[AES256_GCM,data:jCP/gGZFOj4Nuu1gtKpo72LuVZk3xXLf/ra0h7t1gp3I2DpsYpDdhkHgh9lsPCX2/ZBKmLmiAkOX5Q==,iv:sUMKx6A83z/iqT2jlhkq1owGZlzwAP7lrBiC2fjt0LM=,tag:Ni0DR2Q1Lnf9GDs3ZBNCCg==,type:str]
+    - scenario:
+        ID: ENC[AES256_GCM,data:hey7J84=,iv:tYI1YY1MMaZY/Ik+3IbtV3xB9rz4ZqWSbQkkwZ5KIWE=,tag:jvb6Fp377gd1bU7S9XYrCg==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:fwzx3qw=,iv:70S5fwgC3ysvwnw7W32ZZKrug43FMuiRHxmf2c9Fz74=,tag:79mSdsoX7zBo9lBpU2VoCQ==,type:str]
+                description: ENC[AES256_GCM,data:3ocqWoO8Sgatlx5rQ7mvMa6nqEwMZ7re/lRpxK65nCyi0PfLQqsJC45MMDsEvOZlwTbwK0LBD9qFVufBJgN+o9zhZ4/Mlg+FCSyOeq+QPFIT9BsmH00QOdgLVbf7sic4wYzrc5xKjgI7VEqtxCwjpAHvB2o21xD7JK8REDnUhTTi/DkxkKuK9SiVfkKD+NnvxDIhTF4VOEQ48lPDCR7g+oXmL5MJBl/JpQ/DagvA8EZ0Vau0XZJ4UmdQKVykdpgvby1hiHiOynaQWwuIOn1IEZ+XYus4Qg1hKVsN1n/CG9aWF0R+TrY79TeizJvassf2TJBKMvCgrS0cJy7+pT6LwnNdZt9DV5uvkYiG7zjAD30wQA20TV6kl2o1DVkBJIDNLTb38IJsVUrqwpsutX/iWhddEZU8un+76SWHqVs8dcCapRj92NMzItLPV3EfV0pYKCTNKrw7HmeM0N9Lz7pS2CR2U8JiNUuNsL5f5ogevcQg55jrMEQFtBH+nf3E17owu899e1p1853tofRQlbmdhUCFMk2cQyd+lCbqX34i/vmLR3nQ5aZiZXHWzWZv7v5OTMxyKRplShxReE7i6LpfJZQzpKmseApgosOmE/IAUeXZgjA02Ycj0cA/eijhX6c9iAMYRl9u2xuBNXvyili8l1gjmBPAfu2FD5SOu6rDhCRmfo+beF1Gh0Uxl0Ioq/ljy5BI9z3VQYnj4eQ9KKf8VjGlq3d2Q4jhse/pDZpZDC1oBDj9i0OCB+MvwWQVWeg3G+wBSE0uVV3EunNYpHTA+XzsZeHrYwwuSPeOPnxJqZRlvmBBwt7dPrRsCq3JVUaJbCukvX66Vj43LdnNEpb8V4+BDjc6PS8uvdpip7vGuO+GXCPKxKKqNp7vHu22yS2XyADLlrfONT6KORglZe3dDw5mzd47THX7UzBRaBttHPA0fCjlmrsHzndE+GgFqEM3C5EgjXbDXC8dAL6kt/5kjMJjMSJjMuEQazXaZx/1D1Lk8gJjsf593hbsTgtnixHhB2d9GNtzrBsG8lXUGFq0jg9/FBFu8IFmKkxzpXo7zI/kWI2UbUGLSvFESEYqggspN8qDNDr3jPMEt0W38cH2laf3uaEqbPTLmKaFOQ==,iv:Ytm3PbSIaHaffGmqgTQ+6jhD2mgifcjCq83SVagYPc0=,tag:FOzhoNlPs1BJvO+t+lN2BQ==,type:str]
+                status: ENC[AES256_GCM,data:Fc+oXQU/2N2ETtA=,iv:225ar+9QEz/bzL97D0hS5aClagUDoO+NehUTyYy0gPw=,tag:DvH4g2pW0sZ7cQZeaApfGA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:kGIyIYFkAvhy8Swe5x6sXAaGekEsmJPE,iv:l7lwAlC6zKw3P0VfP6S194VtNExhuboKcGnAwO8knt0=,tag:gQR9/3a6m2ixvfPvZx+BWg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:UoBGqCI=,iv:houpf+NtxmPRK7IgSwaZzDF5JIF3QJzZE5bCvYPb1wY=,tag:zWfz/3naOH26nIrzm2KMHg==,type:str]
+                description: ENC[AES256_GCM,data:B0kMj9Vv8pE1+f0kXn4Kjv/IRMB7mjOBKzdDX7Ed/145yffuOKNWzs1QAKHWO5eGj95V1LCTm0vCwL3NMoKi37V2yVY8ll8tDnk9QR46IiH6i4noTykeQI7vxETHt52kbMsU6JJUfUivvFI08JVfKboTypPmub6xZqV9DIeHC/FUHcag/2UzShSl3s9eoWGw6NlSd0c7ZHKOlCDtCMGU+2LJdM2YoIMYuP+q9Kx+w58nipsr5xciwjtBbu08Z/iwZH4heDlYxaVGqq/XoLMb6JoP5BFM8WL3ZFL4Rp50CFZAhvwLAc6HqveE9hJ9cEsTUTVR0wLYabbGnAER1YIH7ogkuNygIyjc6AtdyAm6Bpq9K0qq7Fh/JREzpjgOBtzPOqvd5l6gr+C4Yy6qNckmkXSlkMP/4k7ugpjZFlYiUvS4Q0Bo7zXXDWggCaLSfJGA2PjM/O/O070wD7+8d+wiYd2Oei2/ixH4dycquMtlO5Ifp4k6oGYAYik9JxXpiqty176UyTHPqbvjCtuvCk8R5HQYLXF0XPq2Rv46Umghw1BYZz7ILv38aDFtGK+cCQ40nLvL/XMFJzqm00jCL1txNUa79/VlpCVv6+qB1ea7GsXOIu6orye7S5urxwvwQXhlUzJlPxy+rb7MtIR3nvIpTS4HGnVshNeC6cOijqPb0cRleaivLf5Mb3u9syb8ajSb1JmJ,iv:7W9sIpWQ84+/5Un+h4XfC1bqmxFIsDdMJBMwMppb8ak=,tag:ZfEP9Vsrp85K/jr82WZ80g==,type:str]
+                status: ENC[AES256_GCM,data:k7Re3DsJT97DxG4=,iv:Ycy7mV42RR7UIupfaKoE+3iiC7TbivXZ/5ECeMFS5/o=,tag:pB80oSJgQxFKibKBs15IHg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:NaoagjYjogb4vq6E1LhDroFGtmECjqcd,iv:7d8fzUlc5msF9mDT+Cv9JBD31QWAFFtDqvVb79vEPB0=,tag:aIERv3aqlNxMuQt+b4OxvA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:dYH0x3s=,iv:pydJrPOcj2Fp6wGm20mu/Uhj+qek1ZKtvo1CmB7Kllk=,tag:WufoOmHYDcEbmb18xmh1bg==,type:str]
+                description: ENC[AES256_GCM,data:3KGrnA51Zym8lmAoCuddqPyBEJg4SnhrIiHijC5gRnEsuI4UjLr/9mdeBIA96meaNVSWvLXx3+OF9zUcEOwQz5NPgbh/+wca8Q1eAYQhZGMYQwMNNdjEp1H4ineC9aIlG4wkSJ+yFKNkCVpYpr+8rGjOxPl9hZeS73e+3yoQpnW4PpAGHylCpryK1mk3RajfPmDR+6/rkqTJjLQox/95AcFN9T3pYFuJbKv21aim5BfvM1KpO9+dfOCL6D1avA5o9CZphZ/13qwvcSaIPyuj2InfPC/uwIVX5f2f/H4cHLJwNrduCdDedJR5pzXtg1x57m6vErNoYJN1rTNYnKQb5V0L58Mz0QWl1yD3LLa7TP8vLLfRGIpxJ7wPsSYCVsAZeLqmf5b3bPSqVpyugcvqgW92I7pLc7YpmwPNeNs4I6/vJdAansRNsPq4Egsii0ZF+8cSkFVdoCOcabWHAlpxgrJPueFb+U3lZC2TJG6Q3yLssolF6eS6z80ULjg0Hii+JzMBIcWkoV2OZAYk5Kd1DJcOxkVPpXYu7TtWyVUu6JbQrz6Z3Xo/LCSa0BOgxjlGENT9nyJsB7TsyseAHdCfuWIp/EV0OWgMI0c0bItmFZ/KH6CrvTye3S1CpY6oxH+thiTNEw7yxoJQeJDbSgJk1+ZXezHye3w2mpDcSaQY7mvH5lpu3Xvhj0mxamK6UWor2xSQ7wIUD8E7rI3srV+KkQK2IwTkcoHFAReSON5nZFDRJJ6b0jtH60/MKGNswWLufut4bXs8TfFNNsvWKemK5A==,iv:O83rjhIvg3AoROUqBl4dym/qw5XERuPxTuSytAeNCxg=,tag:LACk4AwPvSAtBO2WXLtRGA==,type:str]
+                status: ENC[AES256_GCM,data:Gn68HOMIdJpMIPM=,iv:KBp7IilpgJrUukPI8a5T9aOrnt6MSQFyVS0zAVj7xL4=,tag:D3EpdVgjuoyevFsY1Qp+Ig==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:5l1Icj8Ic+FABf0fEjajR8h9CpGMDf3OmxEmvohsAEM=,iv:/Kt+IOux1sn1k932H2FW2Mc8Gnx6h+xZHDrQO1t+Yjg=,tag:ljx7EW6t8gbk1J/yKGsrpg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:DvUNHJs=,iv:nyaWqpUW7gAflSmzRWZ0kLvFCuTtXmvkry3i9iZrthE=,tag:cnfGgwIBw9NsZuuKNUarfA==,type:str]
+                description: ENC[AES256_GCM,data:X7zyQTPfeSMNiRk492Bv8JuBy97gr3Qd5vBLZF4J9wIwGkaaXj9CBiTNgrkYK1UW6vQP/JilQy3wuMUvg+Hib7gfq/WIjijk4FbsgylWgDsHxpUsPcnSUTuTBcTk3HJPZTHpX9phraarwYpeuzj5mJiusf0+9PU32MmNYCVz1fynA7FektWpRNTzKF1YwAOPQ7xckX/ntazIb+GFXjrBc9izusaMmI+DBo3iMORGncdDlX5ZyINLWKwuhIi0jFZaTZvgx8KAWr5iOIiQuq7B//n6pWrX+Y/jZh6ZPvTJjm2cT2EGCRcbo0MIvfj8CJPRz7JLE38l+Op90FpMXmTXu/1xCRdDWjbbhFQXXYrde19OIN9i91a8HlIhpTYh4K3v8L7vaUaw/NOxw8krGOB9CUA0epQiDe3upII6wt/1dBYq49byeMSULlLu2CxAc+4x7nxsErldxd+6MD43IbKX7pBBurUeThSGvhj/6Ijwau1Z73tzeM1vg2rwKuU1pvXG4HBxtU4TGnbbF+u0AIrj+ZhBM3paRLkga2vy+CVS2A==,iv:/FFQAcADepesCVH6MQng2vlVeEFsY9XtARCusvDxUI0=,tag:WzesUoqISomee6qgQcwWtA==,type:str]
+                status: ENC[AES256_GCM,data:xAAOmYAB/qmu+74=,iv:E+NNH6vf0UL6dmBXJpUIddXanGAaxoZGjRaOaxOgfzM=,tag:X2/avlMcizvLSGNyB7yDsw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:38Z5xly2axACJeQMimnJiIydpaiAU4d/KJQ=,iv:VMN4d54jIzL84Cj6zpQApTCP1MytC1DncFt04S9/How=,tag:ubn/ixzq1/BklOEsIsnxeg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:F54P9CQ=,iv:5Yzh5ERP0hXTbPEjEzk/ig8Ck3WZYq7zlmiD6hD+l80=,tag:3L85uhnod/J39mMp7GzyHQ==,type:str]
+                description: ENC[AES256_GCM,data:iUUkCZSFnfJWFN4U8S+6ChcMnlnth1n5f9z6v0WXz3V3RdvZfyAk695a3VCvHhvCl4615RA4J5/eO+IUPRQG5LddPRedKdG07Q7ZciH2T6Ty8sxRHSP7yW9eFH5Rzeu4WC2fwvTZWrGxqOxbhoG8ABSlE0/0hq2gqY1Zjk28da8RCHgkzj3sCwvXlDLZ7kz4ed15mGJFeAm7cv5DlnIBSEeYrhuVXdXDNUenR5FUrRb/cuI5PggG9dPLtYqUzgt+kEL7QT5oexlzEpYZBl4kxPUhRjZrQ6Ov5i2JwAC7/vPQonLvqUhVp/tB1qCusHeFnU3ZPP4nsYK0tIOdf63tFj/YBfvFcI5KARa9xyhpqO3E8Z/02KZt83hDdrg3XwG/yDzvkKPhmC9q7FByMXt11c5i5YuM1VeZa+1u1nYvp6lXCZ+FVGQzJHhmC8x1CZFH7t2eG3V3hzPn,iv:jd3AZSZ3Nm1W2W3bujl9UkGbt3bujGxdB9/IDUxiqKM=,tag:IenNOvN2qhdNUyh9RmJ37w==,type:str]
+                status: ENC[AES256_GCM,data:1joITYj8h2Arnpk=,iv:aLlHCQlHTe1k2cq5cN+BkXI6dAMYwSPpkn+4+zgwkj0=,tag:NwynszJTtr5zydRPAcglWQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:SiU+QstwWkzvdNlx7MTdd3H8ZKN+0SWZuPwk,iv:J1iFkHO76uml4QSaCW3VS1eVu4LIXttzCQvl9pmcm6k=,tag:hzhpYokfQ1jjm3hlbqwieQ==,type:str]
+        description: ENC[AES256_GCM,data:09It+HRow/YeEa5TeZ9E4UnFJ7Rw6rsL/VpeSrVh28YfaRaruhBqiHLcKsOP5UTtp/z+BH6+Zy9ebXUz1W/2Ooc8Tl+FGQ+FD8w4Wzo3Q8ifN7/qTBQKepXRP8/oymfsFmZMXTPD5CkEIir2GTfH3r+iY7uiJrEw90Mue70+3UWHYV3UouZVA98DObk=,iv:xENQlNlPm5cr0YRTCpoTDPMkwEUplaXz1tQ5dgn5apE=,tag:3LiFLDVB5prHzUQjCfoeLA==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:pEU9UCOaMQ==,iv:MmcK/EcR9bTVnK/lP5LVzt+v+WnNANwtfvy0/EEJ9ZQ=,tag:IEhfRyBPNYKuLIJzsj64YA==,type:int]
+            probability: ENC[AES256_GCM,data:ushniw==,iv:DfQfre62JuAHPcyPmuV8F40Ic5yKeXNkfBKlQ1Nvp+w=,tag:Zb8koEa6bt4hH9Nqoz6icQ==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:8R5tpLn+Pw==,iv:9Nt6hzBt5GSMDwPNU74R8LjM/IMb4CgptKZTqXcfTrY=,tag:N4ghmwjogE9x3qtUBWgi9g==,type:int]
+            probability: ENC[AES256_GCM,data:5w==,iv:pnjbdFoNvNK93b0wBKltkU5O/m6QpyKEf4GfgC/sRxQ=,tag:bX6KiUZDAQtMJXK3DpBLjQ==,type:int]
+        threatActors:
+            - ENC[AES256_GCM,data:ajVyWA3mhw==,iv:vjoR+9r1u6EX7X4B5fNIl/twOOy4Xr2wIJBSjg6F3FY=,tag:fERmh/t6ybHUzAZaeMl36A==,type:str]
+            - ENC[AES256_GCM,data:rDS5ttMgc1FZJ3KvDjllsqw=,iv:9cPgSJG/lfJtyxNNHGhAIUO8sORQpzlECfjMPVTvlWA=,tag:BXByJGAQpLZjBZZiOqzf5A==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:6olTfnMsMyQdeyoY67c26f6JZw==,iv:yyThkbJsvVF/gnWbDalYYKm0vt5EaMBhfYbbruiQcdo=,tag:Td99HityrcchqtaOfRZBiw==,type:str]
+            - ENC[AES256_GCM,data:S1cHtgnibuwQKUiYSA==,iv:LmlxoD0O7ZQ+isQ75rAQmc1vodWUySsCUQ9mIIBf9cE=,tag:SuKctVPHjn5WT9zfkAlK3A==,type:str]
+      title: ENC[AES256_GCM,data:nWis05tTWss8zvS/fgyR0v67V5e3LskJ3sfShc2XGWJgliPfqz82+zKTXvjXOkdKx83AXQZTsLaldQrssvw=,iv:7K2pdkfVmlG4aKs7KqREN2OQK917MEDnCYKLnXf6Ju4=,tag:L4aMcB/OhdU9XOjvGF8jmA==,type:str]
+    - scenario:
+        ID: ENC[AES256_GCM,data:2GwgLjQ=,iv:/ZuIbCpQKA+ke9EOCi6As90qF8l0h6NFOXleFpwfbAA=,tag:u69m6VWJX16ea5bWXp1UiQ==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:k0NeRXY=,iv:edcddB8SzyrOUYMWagbE2CHOJfkuYP5AJU23+Yww/lY=,tag:4iWwoAxvDxSD6dFam9SDpQ==,type:str]
+                description: ENC[AES256_GCM,data:xzSKQNBT2+5aGSPwkCzaK8mLNvx8NVB3KaryeOhYpZzp+wRvCVEL6tFYkrFAjxU5zqaoUb0ZGl2xjYUlOX8KYIEespMyKRkwXTfZ7xT/O7Sel9aGZoRQ8KIL9Gc5fn1th5xp6V4W01NVc6fCEiCEZpq4zqOasNCO0wDkPBT2nVRpAmelJRAix4WJ/JQ1hpJ2O8HxWRINM7yJxoTM+y1NuYMa47YCs0LEgXP/pRm/hVUpkatptf6ogj2a0EES3SnOepkYU4L2Ruqk2dDsLYSSTNVgINBo2cbAZ4pubyX1mEFMO4bDuykM+2uz/IQsfgUH8eGzFGQWvRNC7izq+l8zWteuYfhBKnUCn3Iwg3yBG+77YO+cz6P+T5kMK7Ttuak2mqlLuglLxgYMAiSnsWwafSM/ytE4TqWXbVcrFehAZt9KEJqNqbdO0Nj+OsYIVBIvMaIPc/I0Lv+UebwHuOxUOJlXBg9gEeyht62U0PrT1UwSmkg/dMMOdEJohDCyXef8T6C9PxkCnH6B0m3nhfiXg8sCfPo8rj75hFQUO9KGxvUwS6f/l0ksliBfzLrQVbi46eyGftWTSRJ1z2KjjB3oTGjwu9YNnANvCpNq3+PEi0xL7X3c6RAHSmAMdqMTCqgmGpqfFx08ihDA+AeQ8vOVaMVWJnzSG6mOB685rdOinHCofqDgc3rkJ7Ii/1wV+7eZRpXeryVUGkv9amrfG/ACPlWqLLD6XPBnCB7+ciFC1ZQNvqzVSg/iN9XodUr6jFjGa6fhAQWTVtucBOgsoj12lWAeZO4VdUJ6KrAT12T1jwegqQKeLZaScFlArhs=,iv:xUuk2QMscxLqAeQBWnkhuee1UOuTM1jCTiJjMh2H51E=,tag:7kM4ZUMgDoI+wzZVAycPUQ==,type:str]
+                status: ENC[AES256_GCM,data:SQIwc0ThIYW0AZo=,iv:dJr8wPbAw463Na7dDCMJkQ5/Uy/7W/THSa6WRQx2+BE=,tag:dzS4NQIy2rObL4gLfM7K0g==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:SLBy7Ks2TDZpa/XD+lTzZxBSMA==,iv:Oe3iDqoRqh8kpqQUkgr3tgeuxV0UVodeWGI8kQ/x+x0=,tag:Hox2VBEac0TEAmrEFr+QUg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:9lVaEIk=,iv:TKhoMw+j8ZqeQKsDUUMGvG3BSOKSIH0OoHojd6gLkmQ=,tag:A93NF7aD2B88y/DPF7bZWQ==,type:str]
+                description: ENC[AES256_GCM,data:sgdGkfLp4UgpwIkS5LLfJBms0EYFpIOmCbKbwYCZj3lgBNnjU9OcXnqaJjN9Y/eKZTxbvjBe5FKB+ws5Uh94Ob6LhiQo/zRB283q4thhZRP2NZKuMcOc1SEflmXqX+NIf6ubN63qKNl6A2iIed18pbElaOnD60rA84lWuPBQFfNQ4GXIgZJHGOhd8XQ0kTrWZhW707q0xkrI0GVGqdJcJwCm6QsUh+prX6IjU17Fk9CtYXMgAxTqrdWLE55ddRROwhw4BPjjJie4VMbs/2QudCayO0oEMA9KaMX1LwbHUAv5VFepmHZ8evHoK00Yq+f8+tVv2g8twqJliMQ0EMSb72D8/dvbWtzvVubz3KFOai9iCNoa2t4y9Wcxb8cNH06sCA==,iv:ENs7H6/Ax3gJzds+vAilGwjHfQZmn9aP6gSnFJpTlPM=,tag:Vf/2e/8VCaqYGFPYF6u55g==,type:str]
+                status: ENC[AES256_GCM,data:Ls8L9VfVnWs1WpQ=,iv:jOWxYCIL+Ukcb5FqLvuXvdX61R5aDMdux+QW/ceHVWg=,tag:ZIbowgz1epdlzoaUfMCeAA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:BihJcr04b2DmqilVghVKdff/Rzq4h1AX,iv:99o16SyiB+Vi7eMj5MxU9swbAnMSALfQ6BAn4cswZks=,tag:Mby2Z7aFSyUhz/UczswvSQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:Qn7TkNc=,iv:97rY0zvJoqQ9ILSUuxxaUl9fLvu8v4ocpC/3Xw3bKHE=,tag:9QlX+0meBzu0xy3wnB8scw==,type:str]
+                description: ENC[AES256_GCM,data:LnubEWua1sP5C5bpNIOqdAWSh+pD7ds3SfP6OJerG6QFfPV3EmLhPf1NW9ZSgn09xH/vzfstRRpn7CcsJN/t5GMLh1JDQB1pBM4Kqm9PiJxvyz+dbZ4g3c/HvjuD/Js5YXygekkpp/7MMD+Ycq6gPbpWvGuLPQqa2rdH0dHo2Sg4XutGK6hDi4Ep47mjP3vG0xgvz/t4TvhxZmw29YLtxDqXWeX5B8xdqtMlyKB4dAHOiUnX32u9GG+sCA9PXNc0YYE3g4tROVpcem51OyPhARcpFUZc/+ODLAk/prMWrsqmzhGxEdWQtom+vXGGpLfMVu/EfmRGiqm3zG368Yye+XUUMX8wHIBIUH0By8AeHg==,iv:84eIhGGSbR4qGmNgIIjLamJYQ2yPTwUTsvU0J53hytQ=,tag:95fQrJBq3gtKbpyj4JBXyA==,type:str]
+                status: ENC[AES256_GCM,data:8mzVHS4DKCpOZcI=,iv:8EItnTDDISCIZ39+rIz0QJoflWdFy6sDNrv9O13dcs8=,tag:WoQSxktkQSq/ZrFGl9VcEA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:xz1hYVTsg9uqEOfLnscOEcU9UQ==,iv:HoMoYoimtzTLuZht18FrOR+4vhMGNvS0wXFx64NlP00=,tag:V+dQjfDzYHC/Mkm/Tg7yEw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:kUv30yw=,iv:IJhXaW/mPkBsJnyi4uepzupEB6XQUC0qK6OnDC99Y08=,tag:pcEJ5Hk5eqCkCt5i4T3QBA==,type:str]
+                description: ENC[AES256_GCM,data:qTOCJFwfsUdvmck6tDBpblZ7EuPHLJmMPVQ7Bztm0QKgCiXkli6nFY11lB8wkj2f9d5hM7l4aJW+fndywR6C8D4GrHx+C3yp0NBx/s3gF1TRSMDFq8wICo1gABAW7uibBBy/rPyXr9viLIEiDIqNJVpbQPPv4VScGwa6LUcMQEgyXQg7ThhPDKSMGH0ZuzlrGcF90If3CCVxGsBVdPtimXUD2TvMsvYPJ1Ew1FbPh7bdZc9HcTR5nBGamu1Bom7NGN2Mldr0p/zjprKIWnEyK8DW0TGonVh7HJkr+Rp3v0LosRjduI6BKXtj9NJ3s2XGqmBz2gShoRCXPReSqwaARBXqWtn0aK28be234/v3ff67f/rvrVFqR82ucscBrPFoG08n39ZE,iv:UOVeqabpVwB2xE5MhVP9j1pOT10E72freytRit2oWkY=,tag:/N42nWxTR6BCRqKdmokkNg==,type:str]
+                status: ENC[AES256_GCM,data:Vw4XdCOj5aZTt7E=,iv:hKPfkOowyXIn4gZ4N4vl2vJwtLFwhvb621xIHFmMGNM=,tag:IofBfqtrciGIkPBttYwzTw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:qveNGn9JLk1KDD/oBGC5a8Z5,iv:lFOsFY6XeZJQkm631tE358gXINz61DAG5Si+XIdBMsg=,tag:xjP4AHyJCaQST3Ja14RIDg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:qX1JuJ0=,iv:eZ4tr1kIzjZV2brDfrDcKL/G4I/FP5ELRP+LMYJByY8=,tag:PsfPw/RAff8WXYGcChwePg==,type:str]
+                description: ENC[AES256_GCM,data:43aP1m41ow8HY7FsWm2BmeHbS4eanNpk4A0Nvz9uxMMyNNEnZRymlNByfl3oRgjMMjThfnLR5q6TFz1xaE0Cw3MAeymNo+ccWffc9iaEHBAtG/6F/DMSmGiYhpIxbVxYP1Jp9wr3+ojjmkmSSasXktMSrFrcufEumQyrpy/Vxl1OGGHZ2OYS+CQmjLvszbBFx4IsBPvksLtD2PveaZoGlZJPDMTF6fCsEpoaTGF/FWnHXIVmDnpSz4J4nadVZNFY7415O/qTKY4l6dgRpirSydqjekzepjcFyygHbRQUdgydSpN1mQqYQGAh4mIdzu8pHKAQCkUes+P8iIApja6RUmWxhcBiyzIZTF4iC2U=,iv:jemvVj68X7nCW1pI6br0tgR9ZA5urt6UekqVGxssr/M=,tag:T7lX4pTipt8S7h4b2/wRFQ==,type:str]
+                status: ENC[AES256_GCM,data:g2Iv+LpXCkKVM9g=,iv:KRWCt3arKc87XkvmxVBYlWDE0Fkflqd5fNZvyHhw0wo=,tag:6BDjmcVffr3YxL3luw2XVA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:Q+PQpk/4Wk2pAohgDzqXymQ6Sn//ofD2,iv:hcf9Nl4V/sTbhiLK8YtdOvLs3XqNi4cBgiyGmFGZGcI=,tag:f/V2yQ+HBRdbxnQB1GCl0g==,type:str]
+        description: ENC[AES256_GCM,data:SGT6c3bX5Kzz5rO0x/M6aE0J+S+WPNc/9asw8IJWZW4W8OHVW4o7JSrlXNoyuuQDgffVbXTo/jQtCXqEsriB9hUNv5+RDvJZR+/znAXsOxabYGeSBgorEPBRpX6Z9W0iXTht/KpjXaG1OInzomdhfkNAoex8vHC5eCE3sknf85AENw8s2CJAT4qCSfGMh2eCLY8gMGCekOMsPp3mCdZIlLenqc1JeJ2VOJ2LDNOzo+74CBKBoZENf5d+5vvtCcOfkS7sNq43eiejxqmDyp9QjiUqtRZ6X90BzzsT6g==,iv:ul/DLaa5NGUCwU+Rk2jtkoADGEg4BQB/fJExXO8kpWo=,tag:SURe65wqweMcoZfh5b/GtQ==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:IyYAdaO8xA==,iv:cMcEFN0YGs0PKdq0qNGSSjJAI+NCDyRg9DRKr/soykc=,tag:1GVC4L5JzzKLW214SaiGNQ==,type:int]
+            probability: ENC[AES256_GCM,data:vGTTtg==,iv:CjW6QMH8cZ+eW2WhwemFnHq/n7t1R+wuvaEDnRBITvA=,tag:iU7siBmcGzOjTtbXzxeEGg==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:aeu3JKViCbk=,iv:7wP9Pj7Lave+C2/+1RjB/gjn91wBy0EzXvvKeFpez+Y=,tag:WORDof2QJs9wc3KoSILl2w==,type:int]
+            probability: ENC[AES256_GCM,data:9w==,iv:Rpb8cjW+II3CGDZPu5M8RbrP5wPs9uEZdREg5GB/sWQ=,tag:ALefJNK6f32JtUAkISd3Eg==,type:int]
+        threatActors:
+            - ENC[AES256_GCM,data:V8dUKzGgyzEx6w==,iv:9uzK1IFiOPj1yz1vuXbylM4EB/LchjOODzsClbAtHaU=,tag:vNAshzBtl3pYEIqqaRaKbw==,type:str]
+            - ENC[AES256_GCM,data:XuyZGwiCd2sj3cGz8A==,iv:s00NJAUN90IXZ4AcHnMS0hiL18BNr1YNfsCORQPrZbg=,tag:PUdeCRpSp5zweOtK6nUWMw==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:AnsB+c813Kbi9xU1U0bwqw==,iv:sDh/cHeY/wsoZa0DwNa1L52OSEnXc8IoAVbOPQuTXfo=,tag:1Gr13FUR5bSt0QU99yeoVQ==,type:str]
+      title: ENC[AES256_GCM,data:UH/v28kih8skcciM7TUTMDg0ZDquvTfqgfVpgn6k523+J4Gl7lUm3TKyw1vyhrGDpy7RJy4ihTXokY2Xshx1QrMmVdr1eljuvyhotSQzA1fmPFnKIyca/kicgvybeqvH4As=,iv:KEdLjub23oUpGHXfurIxrq+LwerWpIAME2nFw6lSaJI=,tag:F08HJoQDR+V1zzHoqyE0+A==,type:str]
+    - scenario:
+        ID: ENC[AES256_GCM,data:uNoPovA=,iv:gV6HqCB92UGL9gNXyHSqVIlPTgb2xas30qWsiLaA7+c=,tag:VlwHY9yF6TGzMkxu7okjdQ==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:gzcYOjc=,iv:jXLK5BN/ukFqUVRWx77F5F7hDB2+Ikky0ibq/znFNu8=,tag:xbMKcq3gnUnZtoG3BU2rZA==,type:str]
+                description: ENC[AES256_GCM,data:uHaiLNJQ/wLUZrOhzL23r+g/0iwV+v78rfdp/Yr40Qe0l4KA7dkcf5ivBFuw9Zs6ItvWnWtPVwc05+z+iaY2je0NuqCYQwg6eVe7XH3mpS3lvnNTFTZ2v5u5YEU4YLDE2uiL8OrVlDIGYqJrVD+KLZq4yu+81/3+/fYS5LTh9gh6tfBEdM0joAzitcvRtL//y+VWp4KEVqrXtio7nR05v5rKpgYYl1Z1Qj9L4CIJfEhhiwpghLE3BKiMrhqSrwFqztRTZqkYf9ejZPGtBIaSHyj0Zw4hVOKxUZTZCmCFCHBLjRPqQLR3KHM8Ieh2R1C0rcXfho4OdIQDYyjH8aHrlMXh5UpVPABbQhh99eKw/EbdRjOEiX9Zu6tzf0abx2+NmFK4V7o4rRwbJBWWkZWpBLjbB8EbmkAlIje+7uJP8/BW02a/i6x0YnlaIJiAB7VKbp/DmPlnxpDnhYHyH+sKsPk9QzlYt6Lgsvoc12u0Fr/rUUoysmNIh1M5tMS/9/mB5qbmMfEyII+8v5e7RqkHMchtbhs=,iv:r4mQ3Cjzdga23IEl1BovhR4JuQ/VTRIYyRj4/jNR0lY=,tag:DpeXTuT1OxA9PnAJbtQoMg==,type:str]
+                status: ENC[AES256_GCM,data:0VebAkg6g/t9vh8=,iv:ZK7k03Z5cHQj+wPcbIQu1vavUs7cTw2VHSdRlNnJ1mA=,tag:19PffJayqRJtGTEhAQ3qpQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:vJ3eXX592jzaqbWrpJkj9Vq05zo=,iv:MgDW1Sk4UYkVocYMk1J0C1vGpPklAgbLN7N8byyK4qc=,tag:nPWG24ioxpKA+Y5ge40cdw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:vGe9gds=,iv:yPUXvEgJJw6Ba1YzQrGRSYXl71AAfIY+FqobX97ZixE=,tag:EBw76t30PbO0CNBhIzaAUQ==,type:str]
+                description: ENC[AES256_GCM,data:JIuyIjL3tV6NU8SOX0UlAFPBCWiwwyrYlphozIW0wAwNaJ1N5MP67/7e9GU3PXwK0ApGTOtOFDuGP6iCmmXE69wE/QSWZjBbvHws+Qi1TG/Zq5Z6TKzG9QpjvQqN/reZE6JyYU9l/Vb4Ed8W/RBB04MHHW078jNA6I38+z+veFEAz0VDCdK6OfEVQS2TQM7mvkcTEDzUQ/ySUXNp6BgZIX5XuBMj75V3rOwEI99M9wv4NhpcCK/EK8CQi3T/j/CfzeROufGetRqbScwokCwXiA6rJxcKji4fOk/UUs4Xym+DxQFfEC1eVUqCEYavKiH6Jv58rMNjFl0kE7GC9f/RKx/x,iv:dHPO/C9uvqGFRc7RZ8GbmmKFyfJwyHtYo4rBrL6QQQU=,tag:No8t9odQD4oONHsIs/gu9w==,type:str]
+                status: ENC[AES256_GCM,data:ckDoV8OxqLlb2wA=,iv:Rihugxsuj6x0kr/1WOsjEr0qWfiraFlhWgpkU2upaG8=,tag:RgyLNoDTPHHu7Zns9mynxA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:1dr7fF9pS4DLn0XCzJRmsUw=,iv:0VizMdvUrUTm86bW+TkIsACj1sAPlm1o0c/sfO19wcc=,tag:SFBjWRXPSW1N2XjXWsIwjQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:yxiJuiM=,iv:li+5Y0fawKAWvT9ZpU5rgVVw8E4GgXYqhpMeFbGiGk8=,tag:t3A+F4iLXG5hgJxq2A1xXA==,type:str]
+                description: ENC[AES256_GCM,data:/oi0KU5sD3htf2pvgWT8Jwm7/3O+3lai7XzIK00V+BPiRt1eoaivHB7dNB8PHh0HYVcpWbKG4pJj9R4PROuPwsWI0/VQUpuy34kOCx2cvr8X3AiaWd05aT3/suuD5eoijJ6R+E17DQOitSyUlR7jDON+pS2HTEekq255RwUnVUUi8ELEVMl6It6wCO8uSrjPREBTghqiV2PrMIpeyLCHfsm24n/I7YipEhB6rfrSBer2LwW9ohHRSidl3ufh50VGK4gxTtc3dX8P+VMAibK9Xr7X5Vd4JeQjzEpT6kOY/q9yybiuTb8K04f9JcfwvGq6O9xVrc+6p/sVIt+L7jS49400J/T+Ts3G4l8HXD9GHBXO4UxpBfm53Lt+UWif58080MQzddCoIVWmocj5NXrlLhzulLVp0ZU6Rgtw8S9cYxaRiXhx0RIibNmVzO0DyfY8NhhrNjw/52BeB/j4DEBQmZecXE7iXax3Da9ic51b3w0xFsS8hNcUqp8f7hbtgmJd2C4YZQ==,iv:TWDmblKLd8kJJI3Ww+iRgGn0IJDIVQ6nCb4qW6s5seM=,tag:6h9KX6JMHjVEBR1fgTxDKQ==,type:str]
+                status: ENC[AES256_GCM,data:B+riNwWw2jBOvds=,iv:q6sYvynxCEjECy3EbAFqpVhU+yk659Fd4mfGddY5+/I=,tag:fT+MxkYAN5bjnvJVOaF9ug==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:VC119lgI1lYkelc3XkJ/Xnvor8Qn3Q==,iv:iM6TdzMCELJaBdTtFGP2k+syMGMJ2usVmH8Zb9tLT9I=,tag:7V5bg4ysic+6SbUudu5B6Q==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:1pKx5RY=,iv:eStkzrED6qYUsMIr241pWdUAT2/KD2GkDv5RPex5UNk=,tag:TNjEngEcJ+8orHG3NVFQiA==,type:str]
+                description: ENC[AES256_GCM,data:qp/MROxlvLseP69e/COba622qEf2h5tAjxIYx5tYaZtJSOZopbHQN++VEu0Fnod2p4YmK7becsv7brUEqPWr2PtunNr7UBLVMLEAJYcPTDcMecYg6O8NoWqFB4NCk8vop6FgzG96ECB7eXnCEuzgkKFrEXkQlsxxTMDz9FigxXF/uplWtBMb++vvxp8EaTeZnsMkhN6qVAzEWLcbOsknC9oAiT+nwspHwUe9oBcKfjOuBVXLeCguMWaxog7wps6cP0WL4yAugov5rT5WVrUlZxzo8oowxcynj5T7w2SjZp724sMcNG/7Tsz/VgwC+8WbcmV1MYkpYDO//9UD/ZfzNgX+IjyxeFXrba/OJNhcI6tvm9Qx8XojdfNrs1jzG3LNhneUFOZnqRXfW46IIrIwwAOCf91Y4C3bqLo9zElbv51iWdZ0NbCjs7mckuH+sT8a+X81X0CPojpiuiY/GwFboA2vWONQqgxDgbhc2sew,iv:yz0HCBfl2E4qZ6t0dHckc4IVf9ufr7LChxbKTcp7x0A=,tag:EyTNdZtU5bIaCzxbhMd4nQ==,type:str]
+                status: ENC[AES256_GCM,data:xqmYBjjRfKW20VA=,iv:u8GUcPUmcCMWfjcIy5HbF3y1s6zHWBFfSBy0kvhX5w0=,tag:jYmCrJV7pQCD7D9zcKVCmQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:X91Jx376WazgFcB8LT8Nhkk27w==,iv:QkvrW+cfanNzgzHrPkVhKmvwHnSf+cGwO0by76TBABY=,tag:JD1EFbBY117sGBqGP44g2Q==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:922+1Uc=,iv:E0XXwFZOz32LWanAvk1PUl7q76M7Zy7AuwA3W9lFe9I=,tag:z8M07FCzi0XkPDBZk/TJ3Q==,type:str]
+                description: ENC[AES256_GCM,data:japZsc1mJEd7H1AX++eCCCU8yJCrnLCOnv8nTmHwD7jxUlrzrIMhmZcUBQYypvhQKuL4KsuLSe7UHbvdmxDNJH4wpxIYyC5FEICruJuqgSXRhZZTR6FH4lu1PxFHz2KLfGkzm10ior2FFYjqNPi17xBSx5rarT2e9nyezDBNWBMzQ3vlk8oKk8CRsd5x9akxgiMp9Ncj5JCUgLm+jEPYblrOWQmx314cFJlrXL/VBlU3JQt25e6tzNXqrAZqJRcMCH0eLoOXyktbZrII60trW2SLUwgNMyFYxmc2GkduuGMD1nkq+NhXz01FMP+PRCGfK89s7M8TWLXJFGL00Xcit/TVTLAu976FDECesA==,iv:rw9OlDAupryYaw31eD6eKJe/86D3f9ZVS+gfrqQGXw8=,tag:IFr7H8FErM+NXX9W/uC6/Q==,type:str]
+                status: ENC[AES256_GCM,data:bBcvier+cIEthoE=,iv:3mp6sShWYTPCoJySsGRQo6Xvk3RHbJw2NblFURvvUFY=,tag:7z6N1D/ZUiUkYP1woM+v0Q==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:s+HiGoN3SESLpsUZ3EhbXdPxwA==,iv:KXgqxY6PGxJEBV2NuhDa6IKaw4xkNcD6TGwzgBzFPFI=,tag:OOIknNTpm7vQRjy2AF07OQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:8+EaVGQ=,iv:uAcFlCOPCIF4p38T1SiZ8cEQd/iMaKlE+SqtRlAQU3Y=,tag:66SfllHD3FyFZuohgFEOzQ==,type:str]
+                description: ENC[AES256_GCM,data:rhkOAwB/I3XJkmlvYvX9aC2jJgFlTcJmt/lSfOe3CHnOUqhX6RywWYu9dePblCwOJeDOGRKspfl0lqfQdxnLyKGP4kPuLr+gHef8QR/9xl03Acg79YdZcCjI7NkUm8QYnGa6Zbt5aY9ZvGw3JLrZNIkmuUB+Ns2+Luz3ysX6umOUu9CLTCE4zRSjaxeR0M2yjOR03KZfvEJ9FtmjPY02jtD9S/pQLyaQbWgVTTQSUuiNbPTnPjB9WA==,iv:MyHmDLE2gM04hoZeDdTd+Yj4E5yr12uGGXxwDvn+VOs=,tag:8M9qUpp1eYh9erLsHCYFfw==,type:str]
+                status: ENC[AES256_GCM,data:GYwurRr5RNA0Iz0=,iv:mkEbRrC5vnekDrcPJMAVX9+Wa5BGeTwxqhV+WlNw69A=,tag:NtwOGtHUiQEfs3Ykh014bw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:UXkua97zIHZt5FVw1I6B,iv:GrRg7uJ6FsLrjLaHNvGuvbB+ldDgmq5gFIqFapegUfg=,tag:nH4eFex4Kl9HqT0ZNHuyMQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:ivAAJ7U=,iv:SC+7kb+Hdq1hP+gg2nWVd3oOYLxEezOe9Tl0p21FEag=,tag:Mtbj5ehwLcUSdyfIKSs9IA==,type:str]
+                description: ENC[AES256_GCM,data:qXBUUexdktlAuIhV2FedxnSTDiRdhY1u0wc034INRFva5XjhnKJWN2sOUSHOnr5ECw1DjhqnhXCO9iZ3JkedH82VQUmeFP1Q+kUU1/tEGot0hdF0DwvlzSV0ao8c8NjYjX33o/hWnf6sNZ/unEAgE+83oMLZAB71JKftnh6lzvfMJIVGUJnhz4ICCaUw7sQfanbPrAX3k7QYwDehKPNOgY0WHovXE/RxWpzphchDyyiiabvErOdGcUHHZzRnOnm9EMmcvKRCJpwlJQBb5N1PidKG57msWosShJcRpeTyUiStQULzz4KsOcr74OhMMVk27YXPPkz+AtyBE6UJhCo/jij6aav4oZ0qihBFtSLeu7+Jugwi0OTnfihMZPkxJYQoxkCJ0ZDzIK16aFK+qNltNbOYiZejNL4esPDePzc91XRG2BvKUPbEGtCzphkT14TEbL1jpSks9pGEwe0Z58MwTLGLqBj3DXtIrnocrD8QxW9De7lYt3skJFp7O4flrCiaRyjmnyknglWFG9CR2b5LoZ0LpSeSLluFt3bo/koJYTpKvCle7hQlM7d8fTdoqwOGOq7vvqa+JpouIQ2EDARYri+uEvatKEjmjI4dp8M8aLuKTkH8ncDK9lydkVjWu8YiNeGR5LqWh8V8jyse1E0=,iv:kZgXFBiBoT/HfMMNUKn3/I+ab4uQuXSUkI29wk8xzJY=,tag:ut/Gdagdbi/tlDx/bHzIkw==,type:str]
+                status: ENC[AES256_GCM,data:f3n7JI3gE2fUD6g=,iv:dokt4LnbFQ8FjjG7X3ArJ0qoOXBQ04pB8yqdsgK2VUo=,tag:qwR8NQ9dv7e0zCVKcQhnOQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:GhX6+QD3Efop4ITVU8S5l2+OyStfgjnHXA==,iv:n4LjMtvs3klKQAOmEh8+QEUqvA7lnt2Dvtug2MH7wLM=,tag:azCDFlb9C/A0AfhP+rgVZg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:4KQ4uB8=,iv:Vj8uuOf5pIp3wC1KRN95mCmb+fCDYIQBQIZqv24i/VM=,tag:su84RC+I52iil8olIf1AQw==,type:str]
+                description: ENC[AES256_GCM,data:5rDk5TUvL10qt1/jY6R/zv6llvZDh87fgyZGI3Ns+QILTkmyVKUtmT7YSOAh75NBr/NvPPo+1VBlXKEFOkTtS3wn0AWfiT1yWCp/7hybjAYgBgvY9i+tn4HOosAy9NO0BHRYyrJCMlCVaY3NHsmgucH2DHR/+igFn6HtMcVtl51xGFqBFK3PN3Alb+JKxVziGZadPQh4KZfanBomTsnmbw0yoiI91xO+DjShOrQSWyoe5vvFy3Wi+915VYzh63QMY/B8wqNDY4vqDvx0jUIM4jd/pTOo2h/+kB5YTkALGcsn6Rm2Dr3rieguMmZOrTVbmjL+C5bf8zdNq2fyq/nJnLzbHdxYEUBRuLK5VHjaRbae35aCOInhKMcKUZqLbMHwZQ9iYsqArmu+MZTN+vn/qWb895CKxAAPECesGg==,iv:gIg8rl4uJocMLmRsudZMl5pk9Yn0Q0jAh0xjDbTDSzc=,tag:B7DgUzJmGR9CvkAbS2nMCA==,type:str]
+                status: ENC[AES256_GCM,data:gkaU8/3MgiYgAsM=,iv:kEIzxjC5jH+eahNpVJZ92mKOrlwatKnZiPHedm2NoZA=,tag:Ss53C2HvyUtDNDImO6ldZA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:OmigU3DYmw089vtT7D4ksI4qRSHm,iv:HU2qD1HCh1V+WeXefJXZetami1moX6fCrlRFASUI/3g=,tag:0g/SRRyCI/fOsHzG9A1j0Q==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:RB61Fj0=,iv:N1h6bLTa2ImOUcSlhHxTAu3D16UAUcvpdBzqX/UGdhI=,tag:w0NQEtxhkk7THGRD7JKBlw==,type:str]
+                description: ENC[AES256_GCM,data:Uf0lQUk1wJK8jdGEt0hmbQ56CQqBkD0syLZpBNaErBNODP3t3I2AlxMzH761w3ngpyz4/84bORuqllf6lOpcdBE7+B/uvWwLlRBY0nV6zfUrmPzjaE05VLpd1Xs6r112cLPc3Mdk9Bj7rKglagoHLcWrbwL1RSwGW+XYNfxvzyTsaySvQgNdDyOdMETkdHBvEiP2mYmBIfIwWMCpocNhML3Mmg/zo+gFyFwIH2Dcnu44,iv:KOKjWKhb8ohFeApUC7ewo0SvDnvQM0O+6jxnwtBM3UE=,tag:eVrR+Vw5kZstDtqMHsf08g==,type:str]
+                status: ENC[AES256_GCM,data:/NcsNJ9SRo6mtKs=,iv:J1e0elxtkw5dcOXsM/RzS2cwFpM2qwIx75MwVW0q/lk=,tag:1quWlD/tnY+2hMwY/ADc/A==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:jHG8QhHrWQ38vdhLA1o7gddfhUxu2A==,iv:mtaM8pr71C0Pc7viMnkeK2mNRi3aGMidM7nU9xy4QZg=,tag:xTohy+58yisLeIJFN5Ta2Q==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:JqBriUg=,iv:eq/zNMv2CSQseycIKt1pLLUrGaPFcjSI9ldYc94M/8g=,tag:kPEY6EosjDqIM95aYjkjGA==,type:str]
+                description: ENC[AES256_GCM,data:JVTEfncgaC7XdjwjgkaBAMoKLD+p+K4aMkWsxnJxFCjifdSvBZD1TgONbo6G6xHWHGDSq/lDNT3u2M5Uo/86AMrBRGpuD9Z66+hUFVwK7Iwsz21FEFBG2xfWq6N2XSnMwgmwEwnb0Az4TZaySw6Ryy/qTB+Q2HDzjTg8k3ZQ1Q4DgNN2bFVTwoNFKmmVlMVJ473HS53LwCYJMqHzjF13Qw0qpIvIJNy44jaMgUd5hjx3CH1kjv46+sgjPpAdkPixdu8OEafVli9QHN5YynabjjWffAj0gUGhK1XoIoTX+s5UlIKOzCQuDHl8LFQ+HQ6D88C/EDrqg1OkwxxGDRNdY6gLAZkHD3MSxJqxSsscnbkKnxPFhkbX8zfcjXy9+yIqEdVjdKt9qqNjIjRk/+wBgH/TU6lFR3MX,iv:PWVGuGmv1Pot2009upt1Aao+wBLZL61lNYgrltAn1LI=,tag:8oBu7nF57a2lmWisxgy3dg==,type:str]
+                status: ENC[AES256_GCM,data:716A20ksYjPyTss=,iv:ZpV5dIuCW386vU6c7N4YUdyynh4R2HkiuJKOc/MnoM4=,tag:vKsF/wD9sjd7Vl7Iw7tzaA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:jaXT30D3gexXppCsNo2e5Jtu/A==,iv:9l7C+hu3wdKvlgzGZECxBWwk8y2vtOHENnYg8oJ2qR4=,tag:qIE01l0jHnMAc6mTEHlegw==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:FZzdPqk=,iv:xkTez9BHW3IvDzcO3jFkiAYZxL5aU/IousBhmVREO+M=,tag:IIxr2SiMoaCbcO//Z7zPFQ==,type:str]
+                description: ENC[AES256_GCM,data:h50oLZkpABdr2OxWPnML++U6MPEfbookoQh3O/3xb1UAehbZKt1/OaWMSko92uY7d+LeiARpkjUYXlQZjhSfR4Gi85RMcTx1F3BkELZkF7+g79a58zMgd4JU87VZaj6hPsUzeAaPh471sD7YLXksHG3BTrtq8JvrI2bbu7J+3Nta5inJ5bGgZo9k6c/ABPk/8UKq+3NhMbrNuUWwW7kGvGwO3OyTypWM2O/oqzbWYASvh/c1gQ0=,iv:o8le72NbIncR2GfPpzJYwemF4pjAfrcl+A8ziDCx/PE=,tag:WHrC6q/cNLhMC2oh0sp6iQ==,type:str]
+                status: ENC[AES256_GCM,data:i8QuLSqIxil9jQY=,iv:vIAHvTQF/c2PC1WeZ27Cg7TY74mSY83fjnugwp0MrbE=,tag:vOKWkHJUBGX/IxNKWS2nng==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:Ueb9/1yDfbzAT+AzCQDnDWiO4Ok=,iv:GC6k6aXwiBic4b5NBow+u81tjPHniuyd3ajyn3fWEwo=,tag:EGleXwbnYNliYjZcfgUPqQ==,type:str]
+        description: ENC[AES256_GCM,data:Wvl4a6BL16MinloSgNDtOpIzp26F5MrUTxqCILfvX6FrWZjNFks25yUAZD0deYfRXKVLsGFd5gnJY0rjS7CoCUG4qzuNPkItp5XMwOow17adopMipRHHYX+aU8E6hjfD1ZIXL2FfyXPT9+viImLlmV7Ji7+xlqK6FNTcYuwtSEPfDmc+Vgnu7PSEzy7NUT4A6BwzNWCvkmzRSgVWfKFMe8sApILw98V4LcR7WhkfO3nQ07cwmiH0ZtxY31vb1VZ2wzVnD/l2aBWBP+I7POww8kHoQTpcXnVYjlfwZVNKc8V1R7eVZTXpx6j0oAJgnkZM,iv:M015AqhRP+aqbxVJSxvZx0OJYHv0vyCxrzADUX3c548=,tag:6UXVZ9X14kEHuRw/RWjHAw==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:Q/eMjIT3Zw==,iv:4hGVKHbv2RdQrjVRFhSjkEcOtFlJEOJ8qWdvmSMaxzI=,tag:MoF3JvrM3TDWpKX9u17LbQ==,type:int]
+            probability: ENC[AES256_GCM,data:QxoUFA==,iv:UifQeB2oDPTsm++FozC7gaR3oqoNBqo18DQtl2bdcU8=,tag:Fxr3hpq/nsTHfsUXLSp0UA==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:DyVFOZGfkw==,iv:PVkDoDWaBa3JhV+9e85ymCr0uM8owySNKAVPKcfiXf8=,tag:6BZOkciF+Vd9HK4tOxhswg==,type:int]
+            probability: ENC[AES256_GCM,data:NZRY,iv:TSSR52IrTmvGLhOfgitYLIFrydSoVeW0BKRffNfiu4w=,tag:DQPgombGS2ncXg8KFxbElw==,type:float]
+        threatActors:
+            - ENC[AES256_GCM,data:ar1XY5dk3H+4JW/kbBqGsSQ=,iv:WDN3cc0bitvOGZ8kE/MTElvl+jfKc9scWGega0/+1Dg=,tag:ab+6qu/XcBwSL9hRAH32GQ==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:RzUPhPN6JjgpNPh53hBVlzaPmOeIuMwH,iv:2j/44wHI2od4Aqr71e1BRHZN+vSDg9iuOuYNaOMhOxI=,tag:9wQRupwjc8nvuxz0G/0zaw==,type:str]
+            - ENC[AES256_GCM,data:pKziR93jolzVlTAST0MSCw==,iv:WyQuRKG2iwCSHz2Fm5GzVRw3PsRz0zNUwZzVAC80KOk=,tag:TQmUNRvGShxDPLuNaNtObA==,type:str]
+      title: ENC[AES256_GCM,data:6JQUTozxYYePPPWVSpdatMzJ+Xqn45r0TzP2yH0aeinzIhGBzdTcPXJMWSuO61tu3b2ttYyfaXXrzF/D7XolzOytR38LltTVAqjt,iv:/Mzjzo+OvCrJaAJPI5fSl/OwQqvYF+feyEztmP4tXI8=,tag:10DfUj0XeaSG/Mqibq6dPg==,type:str]
+    - scenario:
+        ID: ENC[AES256_GCM,data:hatTa54=,iv:ovS0CKq8bLixYkxF7lODFFdjSaEbXyDsDP7mRwOvFXU=,tag:K8nAQgREBNY9j6Yv9iPEvA==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:s5q3nUM=,iv:GoaLTHRTlExtt48pEmgvYIehDTZx2VE8S+vhHyIYJ9Q=,tag:m6NckZRGE2yaC0LR7cKfAA==,type:str]
+                description: ENC[AES256_GCM,data:uBiCCYivZRwAUig8Nys66RObQ6A0i1s4juYYLkMrMMZGA5rrO9n5gGX3Ezghv4Gh78bmFeiMNT0ETyinZbDgIcX/MhkBSZFiAM1OfStW14xegU9/dwZss6IeEdGI0bfBkXKJtBHW9yXnfUXkISTRUaKeoHLBiN7lWFxTh6Q5cGtgUIEkQe8JWeL8fstd53tjxH5+q9sshjYN/z8nKRmz+YQCPCBYZDIIQRG7mxCVsG3A15rYrVEbM2xQwBl+itjYQulONs+YpAoTttl29TYM1i0Wiee6vLofqifHZLdnUQC3IFzSA01LXmJdHF7rG5ja4p884KkxaPUM5tGb8vAcr8ZH5htFjNH4KYNI/muJI8DPP4ZcSGvmw2Ozc0PpW0Fbs80i5D37Ml1CvgKHfbc7Zz8jDTm5YBxZssCntSO4k4qdVwQqGD0ShquV50S5q8xHtdZhAdo2rLzW3Smh9B8xQT19lyzEadSrBJX71/FDjzP5skwTE3/APXs+xE0l001toVjiDG0FFr8bfPnlVAfL1qdo9CG45FaIEmDQegwvL/bxC7+5QuC7WoU6Im+TTHHY3gpGwWuhWPuIiZuJwq1zs3fDlvVVTyflGomeBm0VXi62XZNvkfj8o3vtQlYRQuwg4QovOOaPTGwOVeAt3GjrzN63YhS9t8sUTL6JS6WBFC58,iv:ZuWtKlfficTT9qzWp7K7vk2OQdvl3CZhKu241Yh7wwE=,tag:a9vnez+ESEj+BankT5kCTg==,type:str]
+                status: ENC[AES256_GCM,data:Yqeux0bb92fUT0k=,iv:E1yiP6uPEZ6qEss44hECo5Y/TGXF8K2sFKPv7jL6rjg=,tag:ryC1F/3XYD+chPDQhX1K4w==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:pcJewBsVplvU7RQCwE+DFPPIG12vbLqr5lE=,iv:U/mKjspIHQQTOY2DLlagC+jv3zBvpXlnZ07hXp8xuJw=,tag:URktqvqJnZxBUpoxwU+UNA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:WRFa6/s=,iv:TCbVWuy6shDRp3V+mPTdmPWSF5PrjnI9T/cksT1yPqk=,tag:vU6CCND5MJibLaBc6WvCXA==,type:str]
+                description: ENC[AES256_GCM,data:BWgjFBCHHNREDdvgLEQmr7aWnKE+XhA+6LAVCPBD9eY0pcVXRMrujok/0/+i61QtvKhwHqaJghmdWUE7D+k/L0bebCNyuIh0Xf/pGYJNvjlxCJWqkIv/yTOwqrBBq74d7KvVMtkF2RtX3rpBZa1la0xwr/HmrxtorshtWIbuTvAodVPNVsLKfEvr5nG5kT+omQDVdrUdwr+nM2Wvxr2vM3/uLD8dRAcTivkIqCrzGw3++jsuRf84IgLAjKLZlZM/8GzyTNRwFA==,iv:/pNhWhJyE5lA83zWR/AdDIdfzWk5OfWEi/7IMSm2U9Y=,tag:LML6hO38li3geBWtE1c9Bw==,type:str]
+                status: ENC[AES256_GCM,data:Pzp7ck7wF/WPeOA=,iv:MP7t5GstYtWS+cVbcf5Nh54lymLRJr/kDtcRkQ8yHbc=,tag:m6Sv6CwrCwcaiUOTRIh7ew==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:D9eG1gTdxtENDmjm0NCitzQ=,iv:8rQuyBFHoBr8ULpCk6Bq1jaAqRcxdSmcIPUGXw1Cf6Y=,tag:mddA6bOgJuGHYXm+nGwwmg==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:snCedfw=,iv:NCdlYOfcx/9+pMH9pPeGRQ8rl6JZWtVjlJEHM1OtJcI=,tag:NkbqFxJb20VxQuXOEr+Uaw==,type:str]
+                description: ENC[AES256_GCM,data:NG5yFirgwDkfLJbLXDuo+doSrgVVi92Dbxk5tIPsBsZT2MmcA2WJhtJ9pFOkgVjl5rZDRxiOQRRRvhh6Nw88VnfPwfxkFv4z1IbQN7K6EbWb8f0pMQExqhpyfRTjf7YQXq2fkVBCu4/hIFeD3//ZcK/2oLfOUPhrrfUtxVFdVOlMTdAPE+Gh/2Hop9C3pZB6eaauFK9nN09HJVWHpQlgyOeNndSAGXQ+JU46wtXjJjBLG84fuTyrkM8HYlbzafm4nxU5nb+DGojv02Q7wyH5Cl9mvAfuRozHmhx0jhMTQAkjcls9AjDsqDcf46NMfxpD0PqD2DlVQIQ1MN7eA3/PJmLCG6ATn8IRM5mHJOYT34rqtng2zOguVPKCkK9HF+VRUqoK5TfmnDCCaA2bvfrzfraGipdfiExfxHEM2Ql3M0hRPBJOo7ERbhTuuuUqCsoqX39OkXsW6cAZk34AAIrr4AWEIbbB9DIO4L+GIgYr4Nvxx4qdqnSCisdW1jJoXJbVTFnifSJLwqflkNxe6++Exxqi+WO2Mmb1mB+f9g/5CANNzWruPaBHBgUUfeA=,iv:4Nk/BxXsLMOxWB6UfqSrj1DcyvaY+2wjmFtyjzfK+m4=,tag:uVVev3omwxFoGVGHgzRuPg==,type:str]
+                status: ENC[AES256_GCM,data:o4ut7ai9+FtioeU=,iv:QAr4z4jOibUfGI20Z7g210sR7dh2QyV+xkoE0l1TNbs=,tag:Dv603YzdATPJQs0jD5PVOw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:k8sMkXngazau7jM8k9YFg2LTAjIqlkW7QdY=,iv:NScrx9aUnAUsSUId9f4Go6hSYbV0D4yvIbl4R4FUjnY=,tag:CUbWIjCRmKQtEDh6+40Z/Q==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:8x+I5aE=,iv:ECA5ovm26TcWGzsrlPjpJtTQpYLVV6DSkujZMtYpXiM=,tag:qMiH2Yzl3AXVpo9PpH6VdQ==,type:str]
+                description: ENC[AES256_GCM,data:R4JCeVd9padq1Qsr2pe8+0oHXD7BR/gP3kwJxhg3PSCtR7Gg8Ob6Z/773z+CoTMCBTAQyxlo0ayK1kvvi1z8y1cB0VDHECnWOQryNR+pZhyxblNo6+ZtThpyKZhEB6EviM/ShvL2Qi4/zcVGJcP7fxNt8C0DicI/gKhWzMY3NJ80blh5aStAfpnaY0KxyWZCSyjZfFQY6rTp+rOyF9wzeVbRwAvT6y91zk/bAWn2zEs0vTj6jaCyIaDNMmJ3uTrWTAGqWFeqBhzNSYKkptMWCmF4HNhHzXvU4ru01SpNisGboONa1YlZur1vZLlD+NsyV8bF+uQGDhv1k03VNWfAcWzzV4fbUZ+BsQDvT0wocHC19KTp4bHyzjXCSVJBTRGJ8pkvxi2DIj4VCLn6thzDSPshTwIW///GnkseEcprMfDrXUtRWGAu6MiYQzRqts7E0OjLL/cosyzm6cTRSzjns2Q6jAi34IJYxVUmh2PCEdur2rk2Rkpjy0yLvG6rSiVNqnLm5jF69KS3nqQQbNgDaLETdPp1f8igPUqlthLkYGdo3/nXIHZQKjn3fVu7XWiFLVl39c2lGnVBef4tUIb228uER10bMc5e0Jtb9nGWmdsuKSYM4NrUf/EazJSCYUEzC0f9Vr7OdeXmVH0vkmmBM+zC6DW7gPyLRlpJng4wFbpjQUk/INGrAToCNsIYAh76//ajXi3mUg1dxxrOKP7C0QFpCLhhM7VunJ3LJULhibSKm/chAXsuNuqx9yDedhozSW1MeXiFomCZR5Cu7i0gq0W1VFmy/5PgjCiwx8gH8vpuzrFsg2LJImClXiUw7cdaglMWKlr9tE2pxv1MBXXKulpefxXCZFCSgqLR3DoVvjstUQ1y/Drz5RMYpXZR9r5eYkT6fNvgcRAVQZteR7NXOmJ6Gwai+t8dKemilpQ0aLvk17AqnQ9SaXwTReYlXUD97wG9ThyXapin0IhSxUB4+rkNxqbY/bfeqaotlgkJEMXN1rMvT11d5x/jLrP2Duzv8xnakUsEQaoToa5uLMwB3IZJ7tWUANwUpG6px1QsUPZ1iSHrl1vogwageDQZNb7rB1CWkKAdFyei5w+jTD3Pq8blVHKR/DjywuaahQ/Icg2frTpfN/SDJPOV0yelvoXRqorvYW735hO0boOZAH+vkiORJ5aOkpTsPW/rTLi9cYWVCSVwTrlCAu4PU1xZzNFmLbf3u/gq,iv:sanAcuwCuZO9hwSECKEFmsGO71rPndqMLRYK9X764KQ=,tag:F+iLnUQpFNLGpVweP+/2cA==,type:str]
+                status: ENC[AES256_GCM,data:w5beLjLK/nU/YhM=,iv:tzZ/a1RCSvNZmU0KAAO+JgenYGmF1G1tpCSAddbUMiM=,tag:5AJwWn9Rm+h2hTeQEKDALw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:QGp/qGjk7fbYggEZc3mXbrvqgQ==,iv:cBBKCiEuAhTuLrattWAH4FlSWEyIKEB5LbRG5bq7cwM=,tag:YUdJEc3OSnJCdk6qRC9GLA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:aeprrLA=,iv:TYfLUJK0CCTB4xK3eAdzx89PiVZTWiuviNpF96U/wjQ=,tag:APbIjO2JlFOrxd/AyXLvaA==,type:str]
+                description: ENC[AES256_GCM,data:6HziFXtMLk4y23MpQsj1EBw5vUpSwj2aPOTxJ7e+rsjX+tLpbOMny/zzftNxCj/M8qAiH6BFhgxGKRP7oq5Xevdw8KY+49bGX9z8tW0ZWzR0crqhufnbGWHWs6QAFDISLk6URQ0Hp3cXYirvPXgP5YBik+weVN0fmEPQqZLKmMgU0pqf90Jj0shIMoUb67sw914pwYkaZRtIQuvSz0/prnO9W2PWMJNGxN9NVcxrS2/2WrRY+bhooJ3Zr7d2pNmjCh0wWbNJ3h0bnBaXpx7fthLG1VjNe1pqB6Fr2Gv9QAfu8WbBY/lpcRy6UlVR+Py/xM6QhrDcxo76zoITdSNCcGT1ZouQNo+lsryeO/A4fQE7UNlyWlV4HQj2cL4Y9/DrEze6qUkZOPq4/eXouKEs0jbpIl5uts37zQFbSg==,iv:zmtYucFF/O0IFIHg0P7qmhS1RRil1E0vY8QFGOyGUNM=,tag:Q0e+w4zn1YK27itVs9hpfQ==,type:str]
+                status: ENC[AES256_GCM,data:1G1Km8IuNG/a8p8=,iv:x2augJHF3LTq6GkNGQpjfmb85v6y51W4vQL5soLVSCA=,tag:oGNTGfLJRftvpy4/voPJUw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:E2Q8k1NBTxPgZVfifTf9Tsbvkg7m,iv:y4H8nvXd4ZPM1xjMCjiRve8gtEIa+NfQDmvRJ70b894=,tag:FJBZD2R3al29WotSbGWe0Q==,type:str]
+        description: ENC[AES256_GCM,data:BJ3wqcMCz7zG34dQ1rkveVInp11e/+FzBX3/eTvXhu34V3gSYixgguq05RWHGiWEDJk3ewS9ehBB40c0nILHdcPIik628w3LfpUBYk6PSKPn/usWCxTC5ZE44pA1YgeadKrCzWfWK4xdgTptZOPck1sPeCjCc4/fSPJrzMfN5nCS0dbx8BSG7MoehgkFE+B2eXQCRzSD/NZ+LTToNV2jBwnF2Dval/XQt6Urr5p6EmbP9ZAOQPLjccZ7MyCiKH/Ol9Iyr4RLoYyrfyM9upjaZqtudrEr3QzMIvkueNx5xGPHzU/91jlaqIZhPUl9imVl,iv:A0O2zIWugbRpcouQGATFJg30KSM2lFGdWpCrPfIHZbY=,tag:VuUyVwmS7XtSIllVSR63TA==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:XkhHBrG+xg==,iv:UOERx5JiHC5lyrNEEX+/8v7QAFxQ4ebE8LyHsTC7alo=,tag:9jFvi8gVu3rGxf+Eqh5LmQ==,type:int]
+            probability: ENC[AES256_GCM,data:j3aYGA==,iv:tOVowan1hzgKuwUOuYJwgXPoiqAdWTFx0/t7nsgek0Y=,tag:92v52CIWaLMwzZKmcYWEkw==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:kThsCGsgvTs=,iv:oox6yon+tAUB0ihpI4fVhNaU3kBammfA/x6I8t4NXd0=,tag:UEMam0h+6+ua4L29E8Wlvw==,type:int]
+            probability: ENC[AES256_GCM,data:kw==,iv:LYYLiTtGGEk8K+FuqJHcWuBBzH9YW1j1yvdKp2vAXGs=,tag:tcA1X0EMUsLNR+1wEH9TkQ==,type:int]
+        threatActors:
+            - ENC[AES256_GCM,data:CS9+G9SMWZO+vg==,iv:TzKLmRPjlfonkS0+g7u1wd1U27D76/4gjozTm23cYOQ=,tag:iA9hqE/g9PbQPlG0T2jRVg==,type:str]
+            - ENC[AES256_GCM,data:bAd88dENrg==,iv:7RJfbQq6wS+YRY32QL/k5IZg+uhc6egLeMGArCwFxrk=,tag:ybGzyqvSOoGAWKvyNrFhjg==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:+YG466q+0QQxRbClARoRsC7eVvovWX88,iv:oP9iLhO3iOPLOZWahOwgoxcGlOHbjZIK34ban0ZB6Is=,tag:QR91uAofPKJ1ZnGzCg0OPg==,type:str]
+            - ENC[AES256_GCM,data:SOp/zKy5869Qj+hK1Q+Gkw==,iv:l/sw16Rk9lwJ4cykamkbcUqe/Wv0i+8Nz1SQU6yPAYs=,tag:QUUOduY3ZaALsKVGxUrOZg==,type:str]
+      title: ENC[AES256_GCM,data:aDICljUkInl3v0uHtnKPJvU0EP4dlXwK87as3ma3FVE9KcxlMLFPii8crwuCOhdg4riXGbFPxu+OhzCnURKwxaDSaDCDJA==,iv:d+qALF2Zr3X7HShbYDww/CDjL9ClQls8JexYnUUhxbI=,tag:4Zv8QiNyT3hw+YEzqEHCgA==,type:str]
+    - scenario:
+        ID: ENC[AES256_GCM,data:J8vuyn8=,iv:IciADbzWAIRkntAvrk6Pw48/iLhs2rnmQulxaLgP9Cg=,tag:2GL/ZaagLj0Dyk8kPCZM2A==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:JvQc/Lg=,iv:RLyNfTocgf3VhQeIRwQpLu2vKZlC6VI3G7yoD9QJpkA=,tag:rZzI23M7oDQg+pQLCHgIJQ==,type:str]
+                description: ENC[AES256_GCM,data:hgNHsTdwRQai1sd9nYs0XjFme0NiAdBGscriw0YlOi/CA7Ob7fDip9Np2y8RvC/9vAAo/uCuGCWCpZfOuGS30qVKkR/ZfPtcSgdQLNyK7VDepAba/gspUvmpSi+FJZ6bEd1PSwMOkCc2lApy2TojrYijt9zPEngoIVJmrsNwc1eUzWdUiFTE/aaNsbGptagkkTo3l4Nz3Lel//su9YfjeJ0wpM0J6HA4HR3qBbXeAYywiMkqbYPwsWGj37ae7dYUNFR5abgahAIqkbyolpJBF2xw98EvZVPpCAKlem1NcutculfXfzl/tbp2NSA8D0OA54RcSOtTooabssTEkFEf05QG+46f/1xf2mQWqp2fkEE0niqyMux/ay8cZtwUfjcGTzX91FAMJcS9subbQeKUx9yqE8WhBHMhCE9ztZjpDOAIOqkdcBQz4L8EmDi5UAnSvCRn0vDBJdlRvRcwM+LL+LO9MLkZT6k0j00SGq6Ju2h9q6O8y5a+IJsHs1/8/jJXIRovp+suoQOeccv4j+PtNUJeiew+vaX/cyanLIpy2d8HNZZy7jZ8m4Bd1EUA2HPx5dpi/h2IznQt56sUT8y+QVzGe6/LxhRvXT9+bjyYqo3fuzu5ukQe13mBs16Uu21mC8qoEyMe4n5XeCOPH6fBrwQcNWHlgdcBbMmYHASAVD9zM+brFrZlqFnhXadmqZGPyTb5ued+KkO///d9kTBd9mlGenbXyZCgSHJD2wYVW86RPu18P9K+IYf+iRkd0N10A5caJwK70dkifbrgnLBbBp64nCH3+hEEN4oHaQkFTQzuC5eflI2fBdm+bLAJpBscZQllUwvJ2HZv7Z4VvRyZKVVJalrBuFy/+zY3/943ObktONp2zbNaZ51ZEUanWTWr052ar0HCRpPWDRjaBtTfw92yPDnmJSvj3Idm9YW0uSmU8ssbeYPC9Hk=,iv:+jXE5w0mAuI7KHD0g3ImCg2TrQFv1auNqvNLs2IqG5A=,tag:dGmBGNDP5X8/i+ByyES8Hg==,type:str]
+                status: ENC[AES256_GCM,data:e+BieGw1cXPGnaY=,iv:d9Ax6kTCe8fuZLRGLLU4CcaiS83r94N5ZVtjO/nQ290=,tag:wVJ36cwB3aQXi18AixGVVQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:4mBRJrPLtOEoEkW08PIvqRvJD3uBWSPxhYQ6,iv:K+sV8OGoqT2IgEYerDWIzhFl3FUQi9a3nxrFiGQfQes=,tag:/3cpsfAg3fO5QAJenkJDvA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:5JWPnCo=,iv:CdlFli6TdxiIKBHjqAH8CFv06iHBlFQTtbA9Shk+R2U=,tag:Fktia6wtPYGNvBPPY9HSPA==,type:str]
+                description: ENC[AES256_GCM,data:b1jW2b8y7R8amwCHWZeTjSYW+H1nvud0tVDZ9crLTM8f02RtolFss4082BhCdF3nt9G+DlG5t216aWP8/8X+PF38iY5vpeDTx8FFCz0xUZ/MUGNzj6u4lsJPr+wL8Mpn+7uOmlRN3IUHNdd5aj5TRDN6fpU6Aj1iUZh0g6pghMzBVc2qtRl2CYEQ9PLMt62Gq+mAmVrnOCzp5P9bo59URXdhoMX8VFvAF32REDCZl7q5xNfWsjDvxEmEFsVqXEUh4xDhgzr21SnS3uoQYK2ci4ee+ci6FE0MVYNLBAK5jGSlTA10DCwbHU2QiRG0lhFAKlg1mYxEaPDgrjmZyqfXoPWa10ZyQHvG8apQIybc9EuhINdBGnIa5MDdzF2SvY3KHgzOJCXQg/yAmQO85H8NNDDG88H+sHif/PF41ZnCrhL/oN3JGd33D1eyX3sv/VrDKwP1HIKhunDQNtAj1EhOrqZVGOn7/05LapYZ4E5xjMY6+y2bLSR9B/NJSqZa+iDsnDIQrR2kxcYFrS1dozwaRQMdUEiwYql4RAQAvbtF4BX46DkBuFTb3ZdMmVbKso05kIrlPTFW+Hneu6FDaSzuL+C0sLwomLnUirE097BgVlmIPGZh1fFLZ51n2ThEJ0TnZdLvEHNzy00pIB2DJ9pEIlYjMgeIHpec4j1UVRV5p0oUS1xQkgtS97ZWrnpWo69LFWKQWuA4gz9l0JCDfoodjMKU+x2kYSEBNPYIwncb5KpcDMNxuuzaKJGKYBP3hf/OEpDCEvzg9a1WlrBpGc2226R+ncSj9+4ak27j02uWVy2fk4Vbvh0NkCQvfeUrqgE59oD2cBzzgtp36X49s8mZ1i+QecrloVOTps6DdL0xHtPNEkqYRMpMmYhoziOEtPUXe4n9uZkG6rtAIPQJaZmNLpu+m+LuMiLGI7Ns5V3kyPaVY1duPK+Zc7i7Qp3wAM9t+V0SlYMtHDBczoIghvkjehCoJ1FsgvLmHdbVJLqb34bt86Zsk1FFIT37VJM1+lTgwH1CRcI6kB/D4N4q/ZgDlq6viSowWOmIhudTZXlXQgzjgbaT/9g8AgtN6QgCkulA1kA=,iv:N53hhxKde+buQzdQ3jfDy7/e/gXtzETQcW21GR08qYk=,tag:Noy5F81eGp3E5Y3dAnoGuQ==,type:str]
+                status: ENC[AES256_GCM,data:hLAhliUp3w5zpZg=,iv:h+Bxp0qkVyAUNPACLaZIFqdn0td4g2QnG8gSAHjEB5o=,tag:V86Hszr2i3J8SJmYjyEW3w==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:PUbCq6LU4gYf3IX1aZSRVeYw5UgDVSN5Zg==,iv:lDDxbIq4PDVrhLWMtTryjYJZqiwmVI0vU7D0XkA2IlM=,tag:CgBfDd3hpSO655BVf8ik3g==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:srgWJP4=,iv:KZjlHrOtplR3u0QR1S55Kq/ngkaq0NDT3NGUILJjJpQ=,tag:1XI0gf65SVl+sLupiwAdKw==,type:str]
+                description: ENC[AES256_GCM,data:mE4op5LZ/1w/XWfXikmX93Wb23Qgn4n7Hlr2FhVerN7PghlUNg8JaOo+SCna0W4E+xe29Vz+1aJ8NzFEPC5NrECQqNGrKdRC/nTlAp/5Dxl5lyUiZYbvZJB2mjHhXh58+obQU285xIU1uPqSkwCOgA6DihcgVUwDGMxj33uLZRIhsezTCDtyjQP8GwMFt07Xi4ww4lhxyRf0+ibc4EZ51zMO2yNOOvK9Rzham0CnROll7piX7kovE6DAqYSknuyuBsLMRSuLUkpZCa/1/XGNoOLo9hJrXukUBv6gMUST+3ECndcFjoIn+x/zxQ5Da5AdUFaHhwxOIyVUe7xr+if+XQ8VzO+Le+xvBqwubbpBz2XVfQWu5297zBuF0JlFa/igPQ0i3yKpeEzjJUzdiybgrKb84r6wXFkfuYHFTvl5b2h6KD6GCV/sYNkfptBm2ZUPKYEFO40vp0saWXjvl2M2gteHqNRQqdf43yJq7KWdYV2tWWleorLbyp3Bob1rI3sTbWm8B2dJARb46e/i7CICZKbjyHkmEpDx1d6Jfj5XSUB90A5wuzT8FwGqaBWz/EzHa96MjUwd4SU0ZjlUNGmNCkPGLPHhwGdYMUZUb3qYlCfGsuOoAcNeI0ALEN2uh94keKigPyrrY2RBUqKyAcfekicUFkIQlAm2++gSM0eZt+n0BHwk95GtVH2HgDrSDbKYjZ/k9TA5eGmYVez6bfMtiDnLQF08D1aSu1xRnlFQve2GXuc5Qet4boPEAZ2WO5907iZPeQW/0p1JYhSv7N2tnBiSmJI63FboP89Mb5dokF9l4YFakVzNRQSf8ej22MovSkDt1UvkC49SEPlRyKY1E82oRvw6lEtUul6+U5MTO9ilh8KHYK9gK2rLyD9H5Ls/VyTEbRwBEHgTIewEuaGpx+3ASyTxPvJDkJxHH3yJYhe5LxxtsKCqsG46X9Sb2Jw/hmFioeNWtNybyBa2dvb4xPC+xLBnuXjK+FUGmjopfQ/ZGDVJsJq8Wm0ZUT6gm4FeNzI01HEYsfEL4jaF8UIUX6Cgv1QKLGrYk+hoZsKXJnzB7rx2Dh3+44BjiaZ0ebcEVuGsJZFaYwmXgLbNgFjHRGJkHGzmhL7SrBwLKVfID3ck+EevdRsLf1FVWeZ3kSXUW0OcmDI/r5SC7E1U7/FTEg3tBs350ulCXh1lhfoWQ4iWT6R6jV7ofPOYKhFM4DfOH8oQchABl+Wydiy01Yg1BqTClQt9ckO+gjYU2iAkWrZ8YoScTt6dawcKrA==,iv:6432ldGEpKPJUrkDtW0YarOW4K/xogqavDi1FBGqxD0=,tag:V94ofs04EKskEdJT3QWdTQ==,type:str]
+                status: ENC[AES256_GCM,data:0MY9HpiAYMlO1OY=,iv:SZv7/6yrKRQCc0oJ9cCtqFGrmGyZ9k9GI5Y36D30xQI=,tag:Tzg9WKOw83PzpT9/HSEo4Q==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:y4iYYb+cIecSmyAi7pYXkD0ospy/opbnfrrA,iv:XZYUqcSw06+Ob8ajMAlo/2kFzjU8RktYB9yG1ojJoU4=,tag:30k+Q7V2noW2ATK8bUknLA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:AKEqEFw=,iv:EWTYTzxO9V6xxrZlhbvgUx0kPrnSY+rMBzxoadV3FG0=,tag:oNrgZPxW4BfNkc/DIF8BZA==,type:str]
+                description: ENC[AES256_GCM,data:oM4bF2iscQs+XCYWp+Aw04LmcXAkL6IBWGhIesWiBcqmqXO5+w+iVInJ9/MHZD+IccxHUui1gsDYPga8eYuiOl9SUruqUu9hMI1LYl8au1AwG2IgsvnbeDAacjTn6bzssi5GCqP+4tio7qrTd99BbKCUpBTyGlrb/SlHLgevSUzNj+WlGDRQ5s1xv211V5H1H2BFCJ0cQyGfXiYC03lYWlnfP/lz8I3385HN/1T5yg0NEojJdhzB4LoSyaKnMkNvj49BMRewOvHQX7YFfygsZQvhebiCQ0LgyJIJPM+nR6KCqv/01cPFDHTHGc9Ji6e18KPuQ91sJA==,iv:sLRFi55EMb8SO9yyrcuvWLgWeJPRiDJNdKd5psy9l28=,tag:/X7JqkVPs6crxFWool4C/g==,type:str]
+                status: ENC[AES256_GCM,data:edoTPJO3evOHGj0=,iv:xjHcDAbXzXD091Fmyp/VfU+eTlJaTB3p8bsQOwJ90+g=,tag:An872J5TZQwFmKNpHaTOgQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:5nOyEF75Ew1nRFTZ8bNfkn0JQnBL,iv:mRK6gVeIhHPa2tvmKSC/nmHMmNO3QJWufZVLuBA3/LQ=,tag:2fM/+52ucwl34maUCI2g6A==,type:str]
+        description: ENC[AES256_GCM,data:UC6AyuUOInk+NkH3xAZD2BCTXxKs8UHRBAOtwmJ4L+xhEPA9QEoqSnkdQaB9trCJQtp51lKh1NjeP4Psqno67N0JPNsGJ/Qt6WmW8EF3ofSfIxGHhtrBHvD1TWVXrlTrzZ48tF3u3H56buSl7zAcGE3ZKDCIpoZdU64w/as6Er9FTfydN6Zuw1/bgeJK+SSbCfrGnTH1XJU6hVVPpPD0lGYDdtJMfL9dgDccrDcyxgoAE/xmJgqOgrfo/AFTfsYTVzhriwtzZtpSZgSoFL44WiRJcRYQAd47B1tGfhRY+B4=,iv:p+H9Gq8nb5czaRJkt3s9dpZTURCKnbBa8Ky131Pqohs=,tag:EpLiXomOZ2H2ScQmCRIjkQ==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:ze/9SItaGQ==,iv:VyBOzvTixinIHHZ4R9KiP90xc0JQi/InIRv9m1yyjTA=,tag:FiVK6YtLwpP3aCTxHLzzBA==,type:int]
+            probability: ENC[AES256_GCM,data:VPpvUQ==,iv:vmeagIZWXJTmmWbNPKNawUWBB31z8CEcM7Ie+BjSxcs=,tag:IcMkGVA7zglODTBIwGUN7A==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:ONsnt5NrGuo=,iv:fBkTqt2etGhXnBDA2sp0BHw66zANEFt96y40sVrZJxM=,tag:b+objqfg8X6oi6nR3VHlDA==,type:int]
+            probability: ENC[AES256_GCM,data:Vg==,iv:cvx0wFvYHcdVnbqKO+A1Bn8R7zc/omU9tRcB+883zpo=,tag:uOXc9KQeXbKxZGVDpyL3Kg==,type:int]
+        threatActors:
+            - ENC[AES256_GCM,data:DupjjNCYPlo7QVZKPg==,iv:QSSZPWsQrhHcGp2H/P3cuYDkrSBim+2wDWrR5mBfkoc=,tag:7PaPksQ/lPKYoztyvZg4ag==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:E6FcfMHQK4n5wiAu7iNH7hM6a+da5Kz9,iv:ZqLZwCxKuwLUegd04ES/vGKRjLdXKXdqeum6bHcsy7g=,tag:uQLkBzKVXxtV078Gr4NVRw==,type:str]
+            - ENC[AES256_GCM,data:scNex31WpBKtBzdwyf7WyA==,iv:SIRna0tvCyYAgdOHT1Cj1GH4V7OXiItWO7T68PPsUfM=,tag:c4HN5H/rMvepHZsWlOoMvQ==,type:str]
+      title: ENC[AES256_GCM,data:94To1QmqRGB5ZRd//4S23cy8mNChHyfjGEy0NpwcFzw+OkpH+QJz2MZdYz9SwtG3cqMHR8uUtvQ2x/DsRR83nwtLQQJqTXh08dslMEUZ,iv:sVGl6L5NhxjqKoLJ4sjWT/37VsYLnID0eTrgt4kLI8Q=,tag:PRrhy3287Zr0mA9p44a0pQ==,type:str]
+    - scenario:
+        ID: ENC[AES256_GCM,data:/mKVGUI=,iv:Smbi1FqyvaEwQk+oGVJlqRUDeI0JsANUWETW4F6sboc=,tag:vowvkJ+SojDG6KzdIKt6Bw==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:wrhDay8=,iv:Ee/nzfxQ1UNJbOfqPP7Si3qXYs+/DPdLGbm34VGSgko=,tag:/q54sWdK5EaUtp3c0LDnIQ==,type:str]
+                description: ENC[AES256_GCM,data:XrAzEVAUQn5J/Ilo2DeOvysne5qrHGWs9G/6fEkRW83aNCbMckHQls0si2C7TRp0725snjGIvRigoh3NyskvRV7juwCWGtmtJnoiY9x3pVciUz4X5EIE2p+m0wJVxmWwMQ2qWASDsadSh+LMeY046fk3UefZkttIlhKHIyAMG2p7Sjq65W5y2WjI8Mhzm7YleIYrhNpG9j8VgBrOyttLmxLFVcrbL3iltk44EuiG3UhSngeJm8aLmxryNQC1aMtXnxiDOEV8/1UCLhDB2yxWpN1ilnTI/OgyBoObR3wqD6A8HIIaCXI4lebyxqc1m9Ux0dg3JaKmZZAiv2p1EHwihCXcX1ssG+A6PA50F3ioSEPlgCv6qwtuT6IKtVYmPVs21bxCX0oOtw==,iv:79Foi7BriWRyh/DZ95dDOTOrf/ApLK3ebuOps1o0UXs=,tag:vsJobaam4PXOwUtmCPwFgA==,type:str]
+                status: ENC[AES256_GCM,data:Z3YMcyNHJcvXZks=,iv:6Z3vHU4JBrjygu/qIXLHTPcdIwdrRVAquz9VUxYQyGg=,tag:iQuWWEa0n6ZHlKVjUJVk8g==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:yf7RmFExYAdbbpcfkuYne7v574UdDyMs6MM=,iv:tt6vvC2N/2dHIs6GfWmt7kcmPO6V7DLinGPmn2qXqCE=,tag:cSAOrFEwCcmhBGUmQ+ih9A==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:bXbWpDI=,iv:q92dpxtsIIXQf82HkBqvpEHLknb8ouCNZBBhx8qT2PM=,tag:AB9Uq/+d/Lz9o8RtBbytdg==,type:str]
+                description: ENC[AES256_GCM,data:n9PFVyo/Yls9+/uzl7BAv8If0EPQ51NtwLImtDoRUkpervCZAVxN5pvoP+7WAkGepKORf/HXytEEOg5hmagLmWYHE0NeYFaaDZhKEeyEV/n5YQR25IqeK+xfPMdZxrePPQrG8Dh2LbYQ0oDypwXMVPQO2VGrBwZXv+APvPLjdE6mtg4vEw+7D+dOZ+a6YK+t25Zcl1nb66xk5ywQLQmKHDyV1wfVTcJrtizR2p+uI4KjHI6BpT2Sk9ga2a78XPij9pvjjR29Fs3+hxaPUU/wVZ3iaMBPhf6AUrGJ1xNZkN+zbxdKFPYnt6Pplzjzov8IdMROLOtQsEtjRXptuEb1xigF,iv:XpfXdHDxF8InfXQ1RdDN8MCHe/idtHGFkeQjtlwAzGs=,tag:6lNjca35IwM5L2bSjT1Biw==,type:str]
+                status: ENC[AES256_GCM,data:ofJTotvf3bJ9TVc=,iv:CjA+al/SKw9RxK8ghd5iw05jqXvdVC6ZknCkwlqzhtI=,tag:yKWJfcULKI1abwYDmzynBQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:5mBE3H6WDmTJBXorkWszTIQ0eZJBVPzZ9coAgkwA,iv:Kg4rISqbV2F8/dL2eVhQnuWERj/9UAbhOJe5pe6xTQI=,tag:UgVq1VMdMPFRjSDqRZC0uA==,type:str]
+        description: ENC[AES256_GCM,data:Cm5OeygcYixODVGQiU6LnuQUJJpBBB0BGcw+aQk4I8GNK7Y0Kl0qSuCKtCwxwyNKKRdruq/7xsw5HQGFl9PgnHv0NlmgaIyUV98MiW45+4CW6uT5klQnSPbHDPDWvCKr62z+vXSLBpqKaM7WavBzMNVHEs4N1Q2hdugViKlGUpbOSTz7BzYUuiEOdxO8lXZEV/57AnsuukoKJ2VC4xbHgBVXl13VFPs+urxWPTefdtU92vCerm4NND2fbGcwmaqPZsfAUy3ATXj+SWQXws4WcBGck0FG6DzUCN4+hRihPPHKKsQHBBj1SyKrdZnVL8uWIxaLNEe6DIlfdqb3M7gDR/E=,iv:bvFvDEvEN9kXsczzxbaSdacP4VZ1vbCmHDN0VaTGUIA=,tag:Y4cDWNpudm2N0JgrKne23A==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:xRPb+Awe0g==,iv:qR9MtuhafTa2c/H+gFF901YkMvvgCisZhCD0/zhXVZM=,tag:kYZfDX1/Uh5FWZZtPtGW1A==,type:int]
+            probability: ENC[AES256_GCM,data:FDaJaA==,iv:h+Vngyoh4dbC87aiPjBGRat8ptVgWNVd0HRyUc806CA=,tag:YeC94ydfrV4Okt5T8PaGFw==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:QW/pnPgQqgY=,iv:RFM8rnD4/7HwRaHYVuKBttyX9ukJCV+NbNn9WEYdwT0=,tag:qhYupzBZut5swr3pHLoGBw==,type:int]
+            probability: ENC[AES256_GCM,data:FqeC,iv:kkJ0wR5x6qBOPiDHcw84vdOkQuAop2DPUQURLyC8YW0=,tag:XS8usUHoHkeBSnoHHhJddA==,type:float]
+        threatActors:
+            - ENC[AES256_GCM,data:2S2chx2AHCDAvSx2nskL87A=,iv:iN4gnFiM1jIIwJQaAeghUVjUMT/NMCJXVr6cMYnT4Vk=,tag:bmykCRwI6JTFX1sjYgguSg==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:O1Ug7kU5xXg0E7EDMDodJk55W8XUnaGM,iv:7NCureq9LkEVu5MbdVuY5NyMoffS3+5I5GexPCF93mQ=,tag:d+86wwEl9Y7aNG61Mba1dg==,type:str]
+      title: ENC[AES256_GCM,data:bONB89W9SuQnpJLIMHN+x7Fh04cNZG3hXeYvPhYVazNX4VPIkRNp3Ymp34vAUQjmBkX637TsxewG6L6BNrZQeMaACinxVYyh0cA=,iv:S1bARIdI7C8vkJcrWzgA44p2zDH2e4EX9RfFG7P7k1g=,tag:4MjFgjMar2ogzpzCImtnFg==,type:str]
+    - scenario:
+        ID: ENC[AES256_GCM,data:EtJ1k3M=,iv:5XIMmpNX52mAZIFYbJaRhpRIdIAU5xhmjwTliITVlY4=,tag:ozcBZVGC4Q73XIu8cNjk6w==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:diWHeQY=,iv:yILAVyZr2NEbhdteVDAkkpf3MZ9P8gTfcwU1ca+ErKs=,tag:kc/yYZ5ybUyKuFQLYpuhkA==,type:str]
+                description: ENC[AES256_GCM,data:VnY30NaG1y3AbFU1zzNU3o9d4GBe8zDsgjDie/ITNELsaqpsCyHEwl5sFsiS4vMmctt6WBS6HzLyKoTVSq7gp3lVIzARx2hKEMCN7RdTd61eBlE81+R2qqlZ+mciEgETJptgyQSg7PoIE+LSYJpaKtmxODR6aHKBvjjJLVhyYmCLbpPgnG6ThXzmh9gIgnPzauRur2ZXEuoHBFPV+9CB8f7NLwWaBlTYQ2bvW6+OLzsFyQ9NbP4kVHI3J6sRtUcMTIX6OVGbutj7IT4YGvS6ZkQ3KHMUwJRpqFiiuqaLF6UZQnyO5ZAPU3atRDhwFcDGYIUQ5pQjZzXENgsMoqLqo4+0DDiZf8lYyH3aDWPmEb0OMX0Tkh+W5k6GKQPEQOWi048gMHZ4Lxsy9NzE/+LuL4g1AkF96aT58VR78WA5ibZyEnyiZCTji7lbHMXGJrdJv8N9W1BeRTJXRVQsPGEce2FHWEnfK/e9HdsMPwJE1VttVgym9FeXUM7Va7425YqbXE00PpaeJgfhbMsqVi4Vmm8/Sv4MwQeE7qdUKeV/hkWJXPk+TBg1ddTih8wkP80UUg7YTEAhQ7MFsVNMlbN8SWRIFU5uzLCHGEvhdQJluMHDxc75S0DCrxBmWVqOvzitkUKJNmjhIe4eDxB5RGtCTm3t1fo5bcDm3m0DHTz+hk/jOZAZOtkSpwAuVfdY0C2w9ia8,iv:Zy6CmkCl9pGAT2YEcQQZDLCvDksPLXOQBpqUogDVr3c=,tag:cM8YeghFTwxrqfzV/Pui+Q==,type:str]
+                status: ENC[AES256_GCM,data:Q21wI8c8qe6XtRk=,iv:P9ySNQVQLQ8NX0nEa4Uh/Fa4dTIz4U+Youcg7y0RFis=,tag:3q4zfjkAaCrdoYlDRBpPPQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:mwEXBU95MMArXP0RGfWUc2ojJ8E=,iv:SJSzYMlbek4TdhkTZeu5L9cKCzKf+ysuFv/xeF5wHKY=,tag:se2kEL2rPrx13tUCeJoktA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:3XjMB/M=,iv:4g9TWVO+X0EXu5n326x5a5UEAjZdSicNeM6eKx21ZuQ=,tag:5HTAOZbqBvdekn1+8Uze1g==,type:str]
+                description: ENC[AES256_GCM,data:qM1UFjW2IT6kRrFKF6HI/CQk2/TOidO0PKyJ3HImTimrvKKOnOlBU+Gliwrp7lGOOARGnNmQmhQEBUww2PBDLyCI+yyFRDdhW6qbpWycYX0dF0f8W87e+LpdsoUXMkpqOL9eGWN92daR8fMXM51RFqR7moG0zmT8lYQpqrtonRcWgDM5iKEjH33uq+iwal6W0KiaYUtATUgjnwN4n0H9zLNxiQeY6EpUJ5CtPYdda5iT4c+9HW/YtUjkum2fphNhHadndo1ESyJ/MnEfJWn/gEmS0cHs2kO2QpBw3E/Jnnv2Y8uGZlMtADTDixIs0GzUDnsuxuvj8M2zr36p0AjJlwlzqT1SZAuL6E8yFg8PbBue0jnWbw==,iv:8cjFjLvd2D2e2p+75bAWqmNdbHPE5pJzI9aTtf7Go08=,tag:LeSOUvz31HEfu+IaRFCu8w==,type:str]
+                status: ENC[AES256_GCM,data:7J0Aha8xSZbX9M0=,iv:qZkPmz2+FZKORc/zEp/qv0K9mu2angTKJE23cqFWAH4=,tag:eX7m1MYuSYS5wwvebxvqaw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:4Q1J5NyM2pfOJ3RlehU=,iv:KzmDR7Mj8Hhvmp5yQ6kAT0/ROXXfqkLZ+7Y9Ij2wfBs=,tag:gglT8Dw8t2CHegbPyFmU5w==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:kiktQtE=,iv:DfWXI51HQ6bhErHmL4azYARxovQvbV2/OJeu4Ec6auY=,tag:H1Nxx7tK1dgnMSRy+15nFw==,type:str]
+                description: ENC[AES256_GCM,data:F7uW6r0Osi3Vnr3whnMRnHUmGH8WO4RCvywqdXBvA5wF0IPPQp2WZ/PQeAtObjQLK14tu9DrOlX9Nx1jfeJbraR5K/mdtOhJi1/ijCCCtuJ+eKalgX4bBboYw0QSqC/gJ5bEhTRjpr0gWeGPEcHWv07HKTE1inqgZNzAJ4O2O1LwbcZnYcwak+gXGp5nCtwE0xX4doELokw0yLkwVbZ03tWQrbi8onyFR6sYCIo9cPTa+rcw/gs8BOZXfOHgS3ZazeupZ6KalSLP+ueoq0V06S7hbKSSIysxYPxo740Bw8ExB5ocqw3vBjOSjKmjhO8O6epVQbV90+F5PaiZoMbMnA1aQeUp4S7i169CzBu7cwI3qfYSW1lrc2tuSsd897S81KA6l1cCMBUQvlxaWj96BMPgpziifywLS40R7zogVQg+F4xfyZhfQySOJ9CCH7WpBfPPxBIy4l5wsjawhPuXiX9WvUeU2lo4is3Ybe6yAQZWcppk6xljJqqW6E44QreeSGQg0lNBd89QwEqVSZ4yzyIjogSVIQDXcePsC6IPRLRDc37qlEi5jXzLqhEIioCVfM7jCeojWDiZhAlPKY2SN8rWc0HCvR+lPleGV/iPH2e3/JUdUEW2vaRgCemIBC/lgaTWV5kAH2Nl/87/+BQ0kPqYcHT8k/B0QK9CkLMCHLE7rcXu/WOpkN+I7acvDS/EiM6FV8OSbwYhAxubA4ZvBVsuMJzj7LkwV8I1t+xvcHpti5JrEaCzVNFtwQ5hzD3/DVAUoPZueyE57fVTOsXVA6TNlI3xPe54CatXAlQUBfPWxOv6tePuwLZaJtEh03+CbkgjYhilGGQdWrycd9iwsXpchZ3CeE0lKlS0EobNsAX/AmgFBboqhSokR6jOeyIy/fYy1x4poQ==,iv:Ek1+dOD8lU6UICoJap9Q/dTLdNWrFY+/Xc1OcCApm38=,tag:XHtJWbA9iZdZvVhADWvm3Q==,type:str]
+                status: ENC[AES256_GCM,data:p0NnwENWQ5Sq7qQ=,iv:QoVHFKPsV1/rylKP1+dpLWeoeaZiU69ETHN0U7IzpvU=,tag:Ej+8FO6tgrXRib9JwiLoKw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:LIH93nL78PqXXT0c4gXhe+zanmVoXXQ2Eg==,iv:M9GKvbRevQjangoUxOQtV67iZz1qZGjDaji5DjmtMOk=,tag:fh1XOfpj+5yjn9XXrMxrHA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:iKTMMHU=,iv:Z3MPue3uGfWO40ZJTajJ4ILOj53cs4OJTQRD7ZU02nE=,tag:zdIGDQoEYPy4OA42nJ0aAQ==,type:str]
+                description: ENC[AES256_GCM,data:thDykL7yDzHJSRcxiz9PcVZDQAJkJXWl12crzkIFtmbizG9iHQzKJjrar7fANlHXr26FIkOip0Hfxv4HwMEcu41V4QdWHlUPGmizwQgKRmzPOcGuA1grS3a3Fqh7xYX/0cCj8oqfzuUm0TrBh6/N6RasZy9jPapBMkLU9ORq48hvemGyRhupUwCC0hUpafRFIZsaqZHHuN1iNDiYPGzwP4McK+C+N5f88L4tOcTYZzkBHUPHPXvPQNfy2hu4xEcbQuZOCzjT1Hcg+JEbEmXtEn/xCXkDddbZ1Dt4nJod,iv:EKM2lc5/lqZPOVtxLCkm9wINNOUTkHxcDCqJyNF1lz8=,tag:yxmgtYtCkvWP8mMyKajnNw==,type:str]
+                status: ENC[AES256_GCM,data:8X9gRbKFKbczkm8=,iv:/t28qKaQBFA617kdaAlPs0jyJBTomow6js9LSgGj988=,tag:w9VUMtBKinn4Z+yuVzi4Kw==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:iHAbXoJGsFg78s20kESXlh80T37+j43w+Tw=,iv:ShswCiMkqknHKNDizKK0uNJY4iuAwZYChj3heakPleE=,tag:g2UeOnQ4179BTorrppNZ4w==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:QUVihd4=,iv:efn80f2Y7z6lXJ0XoeE4pp/h7Hc63AAMwc5JeAQxTNQ=,tag:DwKpg+XO2NG2gnTAcWoUDA==,type:str]
+                description: ENC[AES256_GCM,data:sRDfHH5o3oWH864JXmq+kPl5bp0XZo1BG15jOMfRmLqNHNumruyxSWHN7DVhsKjpu1Yghuc0xgvoa6E7rwFoKl1QBdyeKg9yZA+I2hHCfVCKXv39oCrCj2SfQmbHd+97FysAAg2mU8i2ESaJQM84Y8Z2C8AevvSw2r6YieLiA7H6TnyOU/HJ6q9Ch9VedbalGeI3EcmIbItabFQ7odMaZihPdmcjzrSm+0B+GYTp45JUkjWpHJNTPNh7Zhh8qwTevTNveb8e0/5U,iv:pCvVEActWScKJtV07x/iHBp+8IkMnEo3+9g3/oK6jKA=,tag:ARfdMeMPDknJMUMyymelWQ==,type:str]
+                status: ENC[AES256_GCM,data:dvZj53nM3czvDhA=,iv:u32ZrnAB6OqGpXm/sOol/NzJuN4HwwVHdI5nherwScM=,tag:ASXMwK9AuZjE/DtXh7GhaQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:bt9sM/fgqunWn1RAC6xbATcneYs1AQ==,iv:keD69rY1GC4v8dU+Y771Z/9B8DXpkVTCjTAYWKQ9AyI=,tag:2j7QZ83RIT01GmctT1d79Q==,type:str]
+        description: ENC[AES256_GCM,data:T0Wa1RO+b6zrJJDXWcZCl5yqepXpdT/+Yul7jyyXFnBXLoeAhO7TDrfmZLAiusge88HM3ZM5aF3bWqGSrMkfAuKOkXWevBpdOmzqnRlfWSlGMEJusvdUui7YpjGzn5FR7byMeVj5SPSxj111gaOr38e7VEOOaM5tPwtW6Me812fE6awcuaIKuBRi1XyFg2EfE3Ay9I0y3jc6CventDdaq0qtKCa7obIHqj8GGXA7ZnyGUVtX1axa4VeBREh7pXrBAtp0In6JJmEBZQCGm15Ks0wf+l8F6gj4a7Y3hA4Thw==,iv:jXIFayus43Zaz6qLIlA5T8EgBOw5kqNqrRjOKASvat4=,tag:07jxylSzPvOT/yvLw5o1+w==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:mY7xPuRAew==,iv:VWsXs7Y6VHsOKnyDEBxK6NadOpPb5Lppc8R2wpRmPrE=,tag:YxfO5iDH/bIlo1WoiHh2+Q==,type:int]
+            probability: ENC[AES256_GCM,data:M+hixw==,iv:5DS2GtChMDuZEiAdjXxend3X52z8pH6CqNFkVdoVNR8=,tag:RaOIQj4ibGzizm4H1pzzxg==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:88b+w78tbKw=,iv:SS0WpsjLymVdVFriSjBjAWNxR8a25uZpYIAUoSknZO4=,tag:wZsuEZhO3nvna3ndGvHlew==,type:int]
+            probability: ENC[AES256_GCM,data:ImtI,iv:TCtSrFUZSkxzKgsiGwDha3hrJzZ39LkT20Uw5ucA+Fo=,tag:BjPIVHxeaBc3YI27XrZc8w==,type:float]
+        threatActors:
+            - ENC[AES256_GCM,data:4E5RnY8S8WmLVA==,iv:Lsr9IKXryWBpnmKXsu1S1Rv5bpX6612ymnEW9Z9Pf7M=,tag:DqpQakbI0Ij8TwK2Xvmqrg==,type:str]
+            - ENC[AES256_GCM,data:/VAPJtMXniqX+3UV44f4tTo=,iv:pbxPNtYoZRop2phDZGHXiYrnF6Mc4bsrbPDq2l09J3o=,tag:n567d3+TZ8dbcwUzeezxmA==,type:str]
+            - ENC[AES256_GCM,data:EFJlBnvA7w==,iv:5gzPXl+HLM02pn3OHPZ+k2yc0f//zcFdFqdR2UBaZJw=,tag:ybWcPg+d8X4f66HdjrwmMA==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:Lk9+EkaR2lyPm1o49K1vnfJIsh1HV+Xy,iv:rJzsivc8GUA6TScHARMFQznaI7VJF0VNLuh862+TrDg=,tag:58hGQSkqljvzBbYti8ueVA==,type:str]
+      title: ENC[AES256_GCM,data:5opf0C5zgeqhHug13BLKQe50+ykJjOCp2/r45XyRPPsucFKaejRl0rzZWwwlzFynWzLzox/tfhqGfUyBG4lZ0pD9UcP655JUWTRWkRc0aRmGrDr5IVr2Qhxbcp93T308C1XPTFlpxZsGqI2bDZ/7nrIlGrAyeWYP5tWm,iv:0JRJcLDjN+SfXNdu6SWUsFSeei4AxbBVt1q3c2sMt7o=,tag:9m0B3PECaNIa53iMbo3Jsg==,type:str]
+    - scenario:
+        ID: ENC[AES256_GCM,data:YLopUlc=,iv:uHdqX0ryf5s8Q9yYCkn5Xo76Pnynq3xtTxNYzQiCUvk=,tag:DP5PQ/U0/2pP5xD8wDdDmg==,type:str]
+        actions:
+            - action:
+                ID: ENC[AES256_GCM,data:o24+XX8=,iv:emd5Iy5Zh8JeFGvf/n7yo0eh6V4kFQDFdZ0XXGGsAeA=,tag:i3NwDkAoRQ36uolRzn8pRw==,type:str]
+                description: ENC[AES256_GCM,data:tEbiLdhZibX2RfQKXwmIaUjsEa0Ns0UXJePXoaZ50VuvXDGjDAUXuxoFc/+6k+gVnbBT27MaS2I2C9lyuWmr2oOOqmpwGh5u540rJo+hGU/1wn8mt4ZisbOfRHpuWLRKpY3PRLuVBhDkRe/+nm3ztlXu8MzeNioCg/eNHraIosed1ugaehiU5apmk9G1g6526phGjjRHNi6qbWuwK/RavXB6ML/AxvC1+d1e775B1HxxK0jS/wIGh40fC/JGJyh4Vjs5FhFHR1vjTpwOqPVhXJeSHMOQ39z2AAgSt0j/hjd68Shigo76WSuU8Ye4FtDN/R3rZpqWLqFtbHmPOz6c7lOr9p1GPdbaAs/Tf5GSy7RI/GOkm160RUyzK67acHGNmjT5RI25pZRiZfmAnYXQ/fxDdSzifvEKMSrbPWwF6IZ4dD6gLPlP9WX2pVOWROyP3o14Lw==,iv:YYjZvTo5HKZ6fnyzCSPSOwVosYeTNpdckHAU7Jqa8j0=,tag:b3bQW283qr+5FEEgKbtP0w==,type:str]
+                status: ENC[AES256_GCM,data:EMGqMHgUifmLYng=,iv:SdL+fWCR0aiGa01KaUAvCx+HYT1QWecaYHn3KwAfXTk=,tag:8jQE2j5gbN5VNIRzI8mVig==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:TGTR5ffTmuIPApcD0Esm5QkXxns=,iv:hanR0SdLFekVUJvuHHK+RkBKx86A3yBS15DqP+VlfNg=,tag:UG5O4nCnHV+XxEwfcjCDOQ==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:ANB+mlU=,iv:WdUVOtZ/JPkhsbGY3D5xpls1g6byV4DWoh+hZe1Hhp8=,tag:S8/iyzBidrl2pPK2GBTviQ==,type:str]
+                description: ENC[AES256_GCM,data:+DdGu+k0jwPPlgur1hNmJSh3Rmx72kALRGjnTxXTTTM/H9+R/LP63JG8RVr0QRV6bZNkhBztXh2ZExud8HAvsz24A35AWLQQM63+uRq3JyscBD2btjvlXhV1vpbhC/xw5C2e+IBzpDKhaHHYjoZr5SDPYz9+KL+X5zrFGOqDDRNK2MYLm0DVkcZEjXXnvh/B2J6tpe2NuEQHt+1EN/D3zgKBu+lLp4VJt6+YOqWS6hfNpqmvAxgV0af2ptAKYiKtpIiwOoanI93r2SVADWkgc77Y1kmCDgLHH3bOkhEKtE0dLwjGHOofAFkvml953uUqkGltBkikdM40KeckWhEpNzXJLYtrjzaGFoFU8kREpHEMAdQEXvJu8EzVJl5gdVP9uL6WSVCGa1xxzkvUdV/bhxy2oA4AUGQoVaxYX6hAD645wbBSQZiWvrsuVNcs1nhTgqBselkK6mKgds3oBi50XRyAh8N0EVoXRzwK8OkJgsYDG1y7HCfu/XlTfEQ9L6BscvcYchy+qwll8ugU4Ly1CBLtSDav77F6QnA3znU5TXOPpkJECqLxim9FhD8=,iv:P45Ce3sm6j4VVg192G6Y+lfpeB7q5ddomysxq+NkTmg=,tag:rSgZz+81jxbuFAGIwaTu7A==,type:str]
+                status: ENC[AES256_GCM,data:RW0AA7V1HjJikNE=,iv:yoQxUZyz72yLkx0JMvb4g+Z7vwuNJYMBGfdreroVWUY=,tag:TU9cyMv3QrhCpKDaxhj+jg==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:uCpUg5Yi/Vajmea9AoDWGo9P,iv:Zg1kXMXplusDYlWAeALPtsAT0SyMX9IW9RO/LOgvCnE=,tag:FPTKKufEfxFfnNLoZCK+hA==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:rAfKkI4=,iv:lLt/+/sgRx0QlqASyIHgE7KNXEvyvzPffpScKkt2igk=,tag:TxYYemg458zogAsIA5zlSQ==,type:str]
+                description: ENC[AES256_GCM,data:hVtHtQ6bQDby2GCbGqrLYbAxB8MJWqFiVAcgquoiHIs+y+m73bV0rgMWbbcVmO9ULKTHwIBd2sXJe2zKHmM0kBVpMOKdQaSmlZtiILkCozoon2b9eTMKSzc3Yy8ZNBIjc8kRQrwZyjv577sUbpZomHE0F1s7knc/1oUH2TLHcDnUTFkavDrGHGX4ZHNtLXr5Z+HPMS1Ivn8FS5620MJ3yj55MG4UqHdaC5HXhwVCAu5wnAn8Cw6hjUyvj2+NAQ7xguSP7u8YoRiCEhtaXtbE8oUwi6H4BfIBe1NVXU2pE3LWU7spiJkN3Flso+WpRMEFJPzyB2L/L6WypNybfpWyjkyU+KRo4XajOmO8fhAsj7gTeShj10yAn1+HB3vkXztE9ttHcJUhyWLsLbUd8xKxTezU90NZ/BouvcmJ5UPU/DyStyW2eDUfoHTtQfaVEpYxfpAophgyLaM=,iv:3FDQrH415vspLKAAlJNlCQ0G/oIoiT4jc/ijLBwoxjc=,tag:MzjIVfHoCe/uGQbPWkyYXQ==,type:str]
+                status: ENC[AES256_GCM,data:BDikPeZTqwGtRPE=,iv:OhlFdvtlzQr5Qcwc9DHE9TojFOQoOln3NWIFBdxRwQY=,tag:b5W23sew5b4e4rmPyAvPeQ==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:c0C2XEAjeuWoh/64GMc3AQwu/NiO,iv:KYrkveKDJCRSNvqcLbtDPJG/eF6bZMWn2anTu6Pi2fc=,tag:wnFbB2fp5EXTPOefkKJY+Q==,type:str]
+            - action:
+                ID: ENC[AES256_GCM,data:iztcl4s=,iv:mm1Kb+g+z+e/HVF4TcQwP4v85slgO/BTQD1uAFBQiaw=,tag:y0EVWb0Wm59G4gl6+a7ojg==,type:str]
+                description: ENC[AES256_GCM,data:YQvCmtf5PT94BihHKlYsImMQLXCWw621yhHHx2lhJwH0AeUKenY283r1Zh0JEct1NypxmniHmTKPjrQfYkcM/LXciLzXhyTBKypNTLuj+dkVkpooZsVqeqxRI+SRMAtvoQAQiH7NPjtDdWCBCDwkE5ro5/eu4SiXTvvXI8PTOifEUFl7JEXnpDqHne4AVhLHOyZPBwswKrYUb44Mx1y9ywn1uvZoyECpiOUuj8nLOem6rAZ0Uo3cazJzda6FRX6ARgna1lBnT8q45qSEjzui9bjHYZiAXO948LK/X7J465C50METRXFCfiZWycPNh5q7ym2UcNIgHqWJCnpR/UEjESthNdUHOZg52PnTBf73AIoPbOM4zcuoiMC67OUGqWGzfQml8X4IrhtW1hvETMwWGotxPiJAiy9cv8Jp9JMa2bTfYfJJxL1dZ5xuoupEOOj+sCh8sXMLdKmYR+mrDRRn4s+4Vy8hCmySjGQAHYbAiTwLMaiqk+Fhf1HbPS2M3qzPaRDyS5l1MTyztTjvOnQpccW+X3ofdvuthTlNF8lDNbn/W3+VYV9uTNVBGTChz2hZhEFgmMSCh4hmGPu+45lwJcxaUNv4jw==,iv:zQ0T7ZjPInMgDpUFyxalLdjsLfmWcIgB6aVkH2Nzt2o=,tag:s7r66c2IB+e7nwhRsL6hTg==,type:str]
+                status: ENC[AES256_GCM,data:R003Pp66bs219uo=,iv:+KaVrN8PiXOGcqWBEQJsvQneu1Y9uIpSo/PtgIenlCU=,tag:ZQT+SJ2BwsBDb9saIctQXA==,type:str]
+                url: ""
+              title: ENC[AES256_GCM,data:O/h12T7ce5bDSBmyXCYBYQ==,iv:J1oTDrM3rDFMAB6I+Mo6+DwxTz3e3dxUTMuwUe1+7I0=,tag:wVDwR5eNNpewdylBBr5qbw==,type:str]
+        description: ENC[AES256_GCM,data:X0VO5+0TNGznw/n4zfJ+L583EFCEzHwd7z5M48WA1zEA8QEgo7wCVHPRC21sDy6pMahGDlBaN4Nhwn91/T5eMmpj5dQ5AuNYdHnBVa6L1wKATPtns5cEj2rFGGMummcvMsjgrP+hYrtSUBP6WR6xqaPqaFN/iHqEE+0+rTKfGbq3CnrB338Us50Agn1hEps6,iv:2GoQvdpxN0tn5oIRSMQaT8JKLWZmPp6TTUq3CVt026g=,tag:sNBOEQ9Xtd8UD2c6uhQ0Zw==,type:str]
+        remainingRisk:
+            consequence: ENC[AES256_GCM,data:NrtcK1Xx1A==,iv:ZWladqAyNY6zyAYQOWJxGztJk40rHgZQ3qTOfW05HaY=,tag:w0KjrzY8NKWDaLG3UGRqdA==,type:int]
+            probability: ENC[AES256_GCM,data:UL0+ag==,iv:ycHhWruSMDlmKveckisEbafE9YvWwXTSqJc8MIS1lqs=,tag:kzK/aC4k+zFVg5CcT8nylw==,type:float]
+        risk:
+            consequence: ENC[AES256_GCM,data:oEK3YYILMQ==,iv:ANVbsrU45Q1MAvaNG6/2zV+qTN6ikfllp4ZZ1DRoA7k=,tag:zsx7axEDVU2S9VFUAl/Cbw==,type:int]
+            probability: ENC[AES256_GCM,data:Ig==,iv:IFqtFrc+ykeYfzTlW8B+Wf7ZRn271Ip9AzmfeG2uz/M=,tag:l0PkOsVuaPgM06KNzSUR9w==,type:int]
+        threatActors:
+            - ENC[AES256_GCM,data:q6Wu4Ah7vqcoxQ==,iv:UkrOWkfmDyJKqzpfFChSLOst9wRhacNzsskXNZbC5fk=,tag:2qf1WhiS4ENn0H9mJIOJIA==,type:str]
+            - ENC[AES256_GCM,data:kyQCL3VmLQ7fytDcpad+pkk=,iv:zdGUNEckMWOozZ0BdZbO12IyuiAzOQeYqB3brMFKHzY=,tag:hKk0K/Q1qeFwdosDeZZZvQ==,type:str]
+            - ENC[AES256_GCM,data:c7Sr4vcxBw==,iv:w6BmH0thKehd5nl3mh87dohUogUspFzsKe5kyE4edVc=,tag:VsHjhgA6qBl/8V7OfhGC4g==,type:str]
+        vulnerabilities:
+            - ENC[AES256_GCM,data:nKzrxStxAYz6U79Gkq/s,iv:xyQVHtClSfCBIYHD6CPO6DwJXufQs1eyKLoWKKQOq0Y=,tag:23Kmg/1ySdU2cL0lrUicmA==,type:str]
+      title: ENC[AES256_GCM,data:GNfaMrPf0SGpZlYLKyzyaQRnq7aMpQNk455hcNrINt0CRNJG5JM/KjLapRPczHgadlsSQl2feWuIl6cMY5I1o5YF1ikq/Tw=,iv:RgvxEwvZIdqsG41RqHmjxei1hgYAXM53DyIqPfI6cio=,tag:EO1x9AGBmtDqLWxITdYeXw==,type:str]
+sops:
+    shamir_threshold: 2
+    key_groups:
+        - gcp_kms:
+            - resource_id: projects/matrikkelbygning-prod-9e62/locations/europe-north1/keyRings/matrikkelbygning-risc-key-ring/cryptoKeys/matrikkelbygning-risc-crypto-key
+              created_at: "2024-10-29T13:25:44Z"
+              enc: CiQAW+BpQHxQ7DR3ac7BzxxB9AFRB9suWRJDqcS+WAhZaTMUe1oSSQDEkpiZJG7klrbMJMOfYb6SRxGW+uwwJS1wsQKarn6rJ+JpCKfTIVXvwJ4e4ygwNgtXpSvPPLFZVQDLG4uLP0EV3A0m/V1fqyQ=
+          hc_vault: []
+          age:
+            - recipient: age145s860ux96jvx6d7nwvzar588qjmgv5p47sp6nmmt2jnmhqh4scqcuk0mg
+              enc: |
+                -----BEGIN AGE ENCRYPTED FILE-----
+                YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzWjEvV2ZsQmtZaE9Yckhm
+                NG5tZVVqQlR1RXFrbW90OTlKWTZsZVhjTUFrCkN3VGxKODNMczZob0NJc0dnVk5W
+                dlhoSlRhVWQvUTRpNHlMVjhmRUhFamMKLS0tIHBxeWh5NjM4NUYzM3dQUm1HU2d1
+                ME5IQTlxY2lYWHpWNldBRzdaK3NKWWMKnBdoMYcY2Z6Rpluo3cHI9JAaVk6oiM57
+                05IWG3l53WLu/006qvmdbqncYB3HkWZhk35sf4Vve+w219jS1jNA61U=
+                -----END AGE ENCRYPTED FILE-----
+        - hc_vault: []
+          age:
+            - recipient: age18e0t6ve0vdxqzzjt7rxf0r6vzc37fhs5cad2qz40r02c3spzgvvq8uxz23
+              enc: |
+                -----BEGIN AGE ENCRYPTED FILE-----
+                YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQckQrZjRPMEk1aURYTjll
+                endDS1hvK2RzRUgxOVlPQjA3akxzNm5yOTJrCm9JbVBPaWtUd1EvQkZ3UTdrZ3lN
+                VENxdUduNUI3VlV6NUNsSzVXblFwTEUKLS0tIGhYdG9Ycit3aVdJNUNRSURrYkFp
+                WVJaMGhzbnpPVlVhNURwbkZtQzBMQlkKEUu6fnG13O1zJ9RXPpjPgrDRLxqYQAbe
+                y12goUbCXeec6VD+6AArEpgoAlQyyYHhpvmOk6J/Zo3GI/Y1TuZs6LI=
+                -----END AGE ENCRYPTED FILE-----
+            - recipient: age1kjpgclkjev08aa8l2uy277gn0cngrkrkazt240405ezqywkm5axqt3d3tq
+              enc: |
+                -----BEGIN AGE ENCRYPTED FILE-----
+                YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqc1pWRkZhSGcvVFQrODlY
+                MUVxZklHdDRLdlhYcmh5ejlyWHBrT2pON2xFCjZHZ3dXK0xTMW5mczFPbkZyYThY
+                eGxCQVYza3VtanEwZGIxdU9wNWFnZ2cKLS0tIGkyMk92emFBMjdrejRCUkFlRHVB
+                amQ1T0o1M1ZuSHhNcmJNNUcvd1JPM2sKbsLb+rgjhCVw/rh/jqqF5T9e5MgITnVK
+                TaHnMIrAOFxFb/5eqtl3SnTUhGPN+pETCr75mU94XYKM6LoTJYKZlo4=
+                -----END AGE ENCRYPTED FILE-----
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2024-10-29T13:25:55Z"
+    mac: ENC[AES256_GCM,data:YKsK7nuBnbmBElw35NYTH0ZpevXlv9bWASnQKako2XcJO4YyZfAjonjiKjuzoS2azrArqsSttxwG/vFjtimH2HWQMYIGePHSyooSiVkMUwfyx7Ykk0cTXpKBFTCzdXsQz9XXv1OguY+lMJ0z5G5VyLR/2ZmxNZqIuj5QBe3K9Bs=,iv:+ZZJxqwTWQzGTwKGB69WySzuidM8qxcA0mzAhBLxbLU=,tag:yhPAeYA6poIBeXDJWAu0jA==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.9.0

--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,5 +1,0 @@
-version: 3.0
-organization: Eiendom
-product: Bygning Egenregistrering
-repo_types: [Tool]
-platforms: []

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,29 +10,3 @@ spec:
   lifecycle: "production"
   owner: "bygning"
   system: "matrikkel"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Group"
-metadata:
-  name: "security_champion_bygning-github-workflows"
-  title: "Security Champion bygning-github-workflows"
-spec:
-  type: "security_champion"
-  parent: "eiendom_security_champions"
-  members:
-  - "ljooys"
-  children:
-  - "resource:bygning-github-workflows"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Resource"
-metadata:
-  name: "bygning-github-workflows"
-  links:
-  - url: "https://github.com/kartverket/bygning-github-workflows"
-    title: "bygning-github-workflows på GitHub"
-spec:
-  type: "repo"
-  owner: "security_champion_bygning-github-workflows"
-  dependencyOf:
-  - "component:bygning-github-workflows"


### PR DESCRIPTION
## Kort forklart
Denne PRen oppretter filene `.security/risc/.sops.yaml` og `.security\risc\risc-default.risc.yaml`.
I tillegg omdøpes `.sikkerhet/beskrivelse.yaml` til `.security/description.yaml`, og `CODEOWNERS` endres til at Security Champion får eierskap til `.security`. `.sikkerhet`-mappa skal dermed være tom, og derfor slettes den.
`catalog-info.yaml` oppdateres eventuelt til siste versjon, eller opprettes hvis den ikke finnes fra før.

- `.sops.yaml` inneholder nøklene som RiSc-filer skal krypteres med.
- `risc-default.risc.yaml` er den (krypterte) initielle risiko- og sårbarhetsanalysen (RoSen) for repoet basert på [sikkerhetsmetrikkene](https://kartverket.dev/catalog/default/component/bygning-github-workflows/securityMetrics) og vanlige sikkerhetskontrollere.

RoSen kan leses og redigeres i [utviklerportalen](https://kartverket.dev/catalog/default/component/bygning-github-workflows/risc/risc-default).
Det står mer om den initielle RoSen [her](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/1308065798/Initiell+RoS).

## Litt lenger forklart (hvorfor gjør vi dette?)
Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet#Versjon-4.0%3A-Koden%C3%A6r-risiko--og-s%C3%A5rbarhetsanalyse-(RoS)).