### PR TITLE
Legg til IMAGE_VERSION i commit-melding ved promotering av applikasjoner

### DIFF
--- a/.github/workflows/promote-app.yaml
+++ b/.github/workflows/promote-app.yaml
@@ -77,5 +77,5 @@ jobs:
           cp env/$FROM_APPLICATION-version env/$TO_APPLICATION-version
 
           git add --update .
-          git commit -m "Promote application ${{ inputs.application_name }} from '$FROM_APPLICATION' to '$TO_APPLICATION'"
+          git commit -m "Promote application ${{ inputs.application_name }}/$IMAGE_VERSION from $FROM_APPLICATION to $TO_APPLICATION"
           git push


### PR DESCRIPTION
Hvis jeg har gjort det riktig skal dette før til følgende commit-melding:

```
Promote application bygning-backend/v1.2.3@sha256:sdfsdf from tgcp1-dev/matrikkelbygning-ekstern-test/bygning-backend/bygning-backend to atgcp1-prod/matrikkelbygning-main/bygning-backend/bygning-backend
```

SHA hadde strengt tatt ikke vært nødvendig, men da må vi i så fall fiske den ut på noe vis. Dette er ment som en kjapp endring som i hvert fall gir oss versjonsnummer i commit-melding og Slack.

TB-457