### PR TITLE
Justering av commit-melding + inkludere version på update-app-version workflow

### DIFF
--- a/.github/workflows/promote-app.yaml
+++ b/.github/workflows/promote-app.yaml
@@ -77,5 +77,5 @@ jobs:
           cp env/$FROM_APPLICATION-version env/$TO_APPLICATION-version
 
           git add --update .
-          git commit -m "Promote application ${{ inputs.application_name }}/$IMAGE_VERSION from $FROM_APPLICATION to $TO_APPLICATION"
+          git commit -m "Promote $FROM_APPLICATION to $TO_APPLICATION to version $IMAGE_VERSION"
           git push

--- a/.github/workflows/update-app-version.yaml
+++ b/.github/workflows/update-app-version.yaml
@@ -84,5 +84,5 @@ jobs:
           echo "\"$NEW_IMAGE\"" > env/${{ inputs.cluster }}-${{ inputs.env }}/${{ inputs.namespace }}/${{ inputs.application_name }}/${{ inputs.application_name }}-version
 
           git add --update .
-          git commit -m "Update version for application: ${{ inputs.application_name }}"
+          git commit -m "Update application ${{ inputs.application_name }} to version ${{ inputs.image_tag }} in namespace ${{ inputs.cluster }}-${{ inputs.env }}/${{ inputs.namespace }}"
           git push


### PR DESCRIPTION
* Inkluderer versjon i workflow som pusher main automatisk til dev. Den bør nå se sånn ut:

```
Update application bygning-backend to version v1.2.3 in namespace atgcp1-dev/matrikkelbygning-dev
```

* Tilpasser også meldingen ved promotering. Fortsatt litt mye info der, men hvis vi kun ønsker å få ut tag og ikke hele sha-hash må vi gjøre noe triks for å "fiske" ut dette fra versjonsfila, så ser an det litt til det vi ser at vi virkelig trenger det. Meldingen skal se sånn ut ved promotering:

```
Promote atgcp1-dev/matrikkelbygning-ekstern-test/bygning-skjerming/bygning-skjerming to atgcp1-prod/matrikkelbygning-main/bygning-skjerming/bygning-skjerming to version "ghcr.io/kartverket/bygning-skjerming:v0.0.45@sha256:a7de6642b55f2cc8e27e6235812ff32f319f8b847b82fa7442c4eee700986549"
```

TB-457